### PR TITLE
Improvements to DigiKey Search and Inventory Error Handling

### DIFF
--- a/Binner/Binner.Web/ClientApp/src/pages/Inventory.js
+++ b/Binner/Binner.Web/ClientApp/src/pages/Inventory.js
@@ -401,6 +401,10 @@ class Inventory extends Component {
       }
       // refresh recent parts list
       await this.fetchRecentRows();
+    } else if (response.status === 400){
+      // other error (invalid part type, mounting type, etc.)
+      saveMessage = `Failed to update, check Part Type and Mounting Type`;
+      this.setState({ saveMessage });
     }
 
   }

--- a/Binner/Library/Binner.Common/Integrations/DigikeyApi.cs
+++ b/Binner/Library/Binner.Common/Integrations/DigikeyApi.cs
@@ -373,8 +373,11 @@ namespace Binner.Common.Integrations
                     var memberInfos = typeof(Taxonomies).GetMember(taxonomy.ToString());
                     var enumValueMemberInfo = memberInfos.FirstOrDefault(m => m.DeclaringType == typeof(Taxonomies));
                     var valueAttributes = enumValueMemberInfo.GetCustomAttributes(typeof(AlternatesAttribute), false);
-                    var alternateIds = ((AlternatesAttribute)valueAttributes[0]).Ids;
-                    // taxonomies.AddRange(alternateIds);
+                    if (valueAttributes.Length > 0)
+                    {
+                        var alternateIds = ((AlternatesAttribute)valueAttributes[0]).Ids;
+                        // taxonomies.AddRange(alternateIds);
+                    }
                     switch (taxonomy)
                     {
                         case Taxonomies.Resistor:

--- a/Binner/Library/Binner.Common/Integrations/Models/Digikey/KeywordSearchRequest.cs
+++ b/Binner/Library/Binner.Common/Integrations/Models/Digikey/KeywordSearchRequest.cs
@@ -10,7 +10,7 @@ namespace Binner.Common.Integrations.Models.Digikey
         public Filters Filters { get; set; } = new Filters();
         public SortParameters Sort { get; set; } = new SortParameters();
         public int RequestedQuantity { get; set; }
-        public ICollection<SearchOptions> SearchOptions { get; set; } = new List<SearchOptions> { Digikey.SearchOptions.InStock };
+        public ICollection<SearchOptions> SearchOptions { get; set; } = new List<SearchOptions> { };
     }
 
     public enum SearchOptions


### PR DESCRIPTION
Hi, I have some improvements to the app for your consideration:

### "Connectors" Part Type fails DigiKey loookup
This part type has no AlternateIds. This causes the call to `enumValueMemberInfo.GetCustomAttributes` to return a zero length array, which then throws an exception on the line below that tries to access element 0. The client gets nothing back and just spins indefinitely.

It looks like you have all the AlternateId stuff commented out anyway, but I still wrapped this all in an if statement to check array length before accessing it.

### Saving Inventory without Part Type/Mounting Type fails without feedback
This seems to be more due to an issue mostly with DigiKey order import. When importing orders, it creates entries in the database with no Part Type or Mounting Type set. But your PartController class requires these and returns 400 if they aren't there.

So, if you import an order, then try to edit any other fields and click save without also setting these, nothing happens and there is no error in the client since there is no handling for a 400.

I made a small adjustment to inform the user what might be wrong. Here's some notes for your consideration:
- I didn't attempt to change the DigiKey order import to populate these fields, so this doesn't really fix the core problem. I'd argue that these fields should be optional anyway - or at least Mounting Type. For example, Mounting Type doesn't make sense for every part someone may have in their inventory (like I have some spools of wire)
- I was fighting with trying to figure out why the specific error code (from the server's call to `BadRequest`) wasn't getting to the client side, so I could print the specific error in the client UI. From what I can tell, it has something to do with HTTP/2 removing the `statusText` field for some reason. I'm frankly totally unfamiliar with JS/web, so I gave up on this. Arguably my change isn't that great because it hard codes the reason for the error in the client, although nothing is preventing the server from adding/removing potential errors in the future

### DigiKey Search Ignoring Out of Stock
I have some parts that I was trying to manually add to my inventory, that I had bought from DigiKey. But, they wouldn't come up. It turns out there was a filter explicitly only searching for "InStock".

I removed this filter, which I think is harmless, since people may have and want to inventory parts that are not currently in stock - but there might have been a reason why it was there.


Thanks!