### PR TITLE
fix a translation reference bug of 'comp.addPcbModal.popup.cost'

### DIFF
--- a/Binner/Binner.Web/ClientApp/src/components/AddPcbModal.js
+++ b/Binner/Binner.Web/ClientApp/src/components/AddPcbModal.js
@@ -140,7 +140,7 @@ export function AddPcbModal(props) {
               <Form.Field width={4}>
                 <Popup
                   wide
-                  content={<p>{t('comp.addPcbModal.popup.name', "The cost to produce a single PCB board (without components). If using quantity, only specify the cost for a single board as quantity will be taken into consideration.")}</p>}
+                  content={<p>{t('comp.addPcbModal.popup.cost', "The cost to produce a single PCB board (without components). If using quantity, only specify the cost for a single board as quantity will be taken into consideration.")}</p>}
                   trigger={<Form.Field>
                     <label>{t('label.cost', "Cost")}</label>
                     <Input


### PR DESCRIPTION
The correct pop-up message shown as the following picture:

![微信截图_20230425193224](https://user-images.githubusercontent.com/64795/234264101-e23412f4-ca57-48b9-ae02-5f2603fa0114.png)

