### PR TITLE
Releases/v2.5.9

### DIFF
--- a/Binner/Binner.Web/ClientApp/public/locales/en/translation.json
+++ b/Binner/Binner.Web/ClientApp/public/locales/en/translation.json
@@ -377,6 +377,10 @@
         "totalPartTypes": "Total Part Types",
         "totalUserFiles": "Total User Files",
         "userFilesSize": "User Files Size"
+      },
+      "backupRestore": {
+        "title": "Backup/Restore",
+        "baseDescription": "Backup or restore your Binner installation."
       }
     },
     "backup": {
@@ -900,7 +904,9 @@
       "customNote": "Provide a custom note",
       "produceHistory": "View production history",
       "movePart": "Move selected parts to another tab"
-    }
+    },
+    "makerSubscriptionRequired": "Requires a Maker level subscription. <1>Click here</1> for details.",
+    "proSubscriptionRequired": "Requires a Professional level subscription. <1>Click here</1> for details."
   },
   "footer": {
     "version": "Version",

--- a/Binner/Binner.Web/ClientApp/public/locales/en/translation.json
+++ b/Binner/Binner.Web/ClientApp/public/locales/en/translation.json
@@ -68,7 +68,10 @@
         "deleteLocalFile": "Delete this local file",
         "technicalSpecs": "View technical specs",
         "compliance": "View compliance information",
-        "cadModels": "View CAD Models available for this part"
+        "cadModels": "View CAD Models available for this part",
+        "symbolName": "Associate a KiCad symbol name with this part",
+        "footprintName": "Associate a KiCad footprint name with this part",
+        "extensionValue": "Associate a custom value with this part"
       }
     },
     "lowInventory": {
@@ -493,6 +496,10 @@
       "arrowPartNumber": "Arrow Part Number",
       "packageType": "Package Type",
       "mountingType": "Mounting Type",
+      "symbolName": "Symbol Name",
+      "footprintName": "Footprint Name",
+      "extensionValue1": "Extension Value 1",
+      "extensionValue2": "Extension Value 2",
       "ok": "Ok",
       "popup": {
         "lowStock": "Quantities below this value will indicate the part is low on stock.",
@@ -786,7 +793,11 @@
     "allowLogin": "Allow Login",
     "active": "Active",
     "inactive": "Inactive",
-    "rowsPerPage": "Rows per page"
+    "rowsPerPage": "Rows per page",
+    "symbolName": "KiCad Symbol Name",
+    "footprintName": "KiCad Footprint Name",
+    "extensionValue1": "Extension Value 1",
+    "extensionValue2": "Extension Value 2"
   },
   "message": {
     "noPartsAdded": "No parts added.",

--- a/Binner/Binner.Web/ClientApp/src/components/PartTypeSelector.css
+++ b/Binner/Binner.Web/ClientApp/src/components/PartTypeSelector.css
@@ -2,7 +2,8 @@
 	position: relative;
 }
 
-.partTypeSelector-container div.icon:has(+ .partTypeSelector) {
+/*.partTypeSelector-container div.icon:has(+ .partTypeSelector) { (no support in firefox yet) */
+	.partTypeSelector-container div.icon {
 	position: absolute;
 	top: 8px;
 	left: 10px;

--- a/Binner/Binner.Web/ClientApp/src/components/PartsGrid2Memoized.js
+++ b/Binner/Binner.Web/ClientApp/src/components/PartsGrid2Memoized.js
@@ -488,7 +488,7 @@ PartsGrid2Memoized.propTypes = {
 
 PartsGrid2Memoized.defaultProps = {
   loading: true,
-  columns: "partNumber,quantity,lowStockThreshold,manufacturerPartNumber,description,partType,packageType,mountingType,location,binNumber,binNumber2,cost,digikeyPartNumber,mouserPartNumber,arrowPartNumber,datasheetUrl,print,delete",
+  columns: "partNumber,quantity,lowStockThreshold,manufacturerPartNumber,description,partType,packageType,mountingType,location,binNumber,binNumber2,cost,digikeyPartNumber,mouserPartNumber,arrowPartNumber,datasheetUrl,print,delete,symbolName,footprintName,extensionValue1,extensionValue2",
   defaultVisibleColumns: "partNumber,quantity,manufacturerPartNumber,description,partType,location,binNumber,binNumber2,cost,datasheetUrl,print,delete",
   page: 1,
   totalPages: 1,

--- a/Binner/Binner.Web/ClientApp/src/components/PcbHistoryModal.js
+++ b/Binner/Binner.Web/ClientApp/src/components/PcbHistoryModal.js
@@ -94,7 +94,7 @@ export function PcbHistoryModal(props) {
     switch(e.target.name) {
       case "pcbCost":
         entity.pcbCost = parseFloat(entity.pcbCost).toFixed(2);
-        updatePcb(entity);
+        updatePcbHistory(entity);
         break;
       default:
         break;
@@ -102,15 +102,15 @@ export function PcbHistoryModal(props) {
     await inlineSave();
   };
 
-	const handleInlineChange = (e, control, pcb) => {   
-    pcb[control.name] = control.value;
-    updatePcb(pcb);
+	const handleInlineChange = (e, control, pcbHistory) => {   
+    pcbHistory[control.name] = control.value;
+    updatePcbHistory(pcbHistory);
   };
 
-  const updatePcb = (pcb) => {
+  const updatePcbHistory = (pcbHistory) => {
     const newPcbs = history.pcbs.map((item, i) => {
-      if (item.pcbId === pcb.pcbId)
-        return pcb;
+      if (item.projectPcbProduceHistoryId === pcbHistory.projectPcbProduceHistoryId)
+        return pcbHistory;
       else
         return item;
     });
@@ -180,6 +180,7 @@ export function PcbHistoryModal(props) {
               <Table className="history">
                 <Table.Header>
                   <Table.Row>
+                    <Table.HeaderCell>{t('label.id', "Id")}</Table.HeaderCell>
                     <Table.HeaderCell>{t('label.pcb', "PCB")}</Table.HeaderCell>
                     <Table.HeaderCell width={1}>
                       <Popup 
@@ -201,6 +202,7 @@ export function PcbHistoryModal(props) {
                 <Table.Body>
                   {history && history.pcbs && history.pcbs.map((hpcb, key) => (
                     <Table.Row key={key} onMouseOver={() => setImageIndex(key)}>
+                      <Table.Cell>{hpcb.projectPcbProduceHistoryId}</Table.Cell>
                       <Table.Cell>{hpcb.pcb.name}</Table.Cell>
                       <Table.Cell><Input className="inline-editable" transparent type='text' name='pcbQuantity' onFocus={focusColumn} onClick={focusColumn} onBlur={e => saveColumn(e, hpcb)} onChange={(e, control) => handleInlineChange(e, control, hpcb)} value={hpcb.pcbQuantity || ''} fluid /></Table.Cell>
                       <Table.Cell>{hpcb.partsConsumed}</Table.Cell>

--- a/Binner/Binner.Web/ClientApp/src/custom.css
+++ b/Binner/Binner.Web/ClientApp/src/custom.css
@@ -727,6 +727,11 @@ section.formHeader {
     margin-top: 0px;
 }
 
+/* fix for firefox */
+.ui.modal.pcbHistoryModal .content {
+    display: flex;
+}
+
 .ui.modal .content:has(.image.square) {
     display: flex;
 }

--- a/Binner/Binner.Web/ClientApp/src/pages/Inventory.js
+++ b/Binner/Binner.Web/ClientApp/src/pages/Inventory.js
@@ -1011,7 +1011,7 @@ export function Inventory(props) {
                     {!isEditing && partExistsInInventory && 
                       <span><Icon name="warning sign" color="yellow" />
                       <Trans i18nKey="page.inventory.partExists">
-                        This <Link to={`/inventory/${inputPartNumber}`}>part</Link> <span>already exists</span> in your inventory.
+                        This <Link to={`/inventory/${encodeURIComponent(inputPartNumber)}`}>part</Link> <span>already exists</span> in your inventory.
                       </Trans>
                       </span>}
                   </div>

--- a/Binner/Binner.Web/ClientApp/src/pages/Inventory.js
+++ b/Binner/Binner.Web/ClientApp/src/pages/Inventory.js
@@ -84,6 +84,10 @@ export function Inventory(props) {
     projectId: "",
     supplier: "",
     supplierPartNumber: "",
+    symbolName: "",
+    footprintName: "",
+    extensionValue1: "",
+    extensionValue2: "",
     storedFiles: []
   };
 
@@ -715,7 +719,11 @@ export function Inventory(props) {
       manufacturerPartNumber: "",
       imageUrl: "",
       supplier: "",
-      supplierPartNumber: ""
+      supplierPartNumber: "",
+      symbolName: "",
+      footprintName: "",
+      extensionValue1: "",
+      extensionValue2: "",
     };
     setPart(clearedPart);
     setLoadingPartMetadata(false);
@@ -1341,6 +1349,36 @@ export function Inventory(props) {
               <Form.Field width={4}>
                 <label>{t('label.arrowPartNumber', "Arrow Part Number")}</label>
                 <ClearableInput placeholder='595-LM358AP' value={part.arrowPartNumber || ''} onChange={handleChange} name='arrowPartNumber' />
+              </Form.Field>
+            </Form.Group>
+            <Form.Group>
+              <Form.Field width={4}>
+                <label>{t('label.symbolName', "KiCad Symbol Name")}</label>
+                <Popup 
+                  content={<p>{t('page.inventory.popup.symbolName', "Associate a KiCad symbol name with this part")}</p>}
+                  trigger={<ClearableInput placeholder='R_0601' value={part.symbolName || ''} onChange={handleChange} name='symbolName' />} 
+                 />
+              </Form.Field>
+              <Form.Field width={4}>
+                <label>{t('label.footprintName', "KiCad Footprint Name")}</label>
+                <Popup 
+                  content={<p>{t('page.inventory.popup.footprintName', "Associate a KiCad footprint name with this part")}</p>}
+                  trigger={<ClearableInput placeholder='Resistor SMD 0601_1608Matric' value={part.footprintName || ''} onChange={handleChange} name='footprintName' />} 
+                 />                
+              </Form.Field>
+              <Form.Field width={4}>
+                <label>{t('label.extensionValue1', "Extension Value 1")}</label>
+                <Popup 
+                  content={<p>{t('page.inventory.popup.extensionValue', "Associate a custom value with this part")}</p>}
+                  trigger={<ClearableInput placeholder='' value={part.extensionValue1 || ''} onChange={handleChange} name='extensionValue1' />} 
+                 />
+              </Form.Field>
+              <Form.Field width={4}>
+                <label>{t('label.extensionValue2', "Extension Value 2")}</label>
+                <Popup 
+                  content={<p>{t('page.inventory.popup.extensionValue', "Associate a custom value with this part")}</p>}
+                  trigger={<ClearableInput placeholder='' value={part.extensionValue2 || ''} onChange={handleChange} name='extensionValue2' />} 
+                 />
               </Form.Field>
             </Form.Group>
           </Segment>}

--- a/Binner/Binner.Web/ClientApp/src/pages/PartTypes.css
+++ b/Binner/Binner.Web/ClientApp/src/pages/PartTypes.css
@@ -30,6 +30,7 @@
 
 .field.icons .ui.dropdown .item svg {
 	margin-left: 10px;
+	color: #bbb;
 }
 
 .field.icons .ui.dropdown .item span {

--- a/Binner/Binner.Web/ClientApp/src/pages/Project.js
+++ b/Binner/Binner.Web/ClientApp/src/pages/Project.js
@@ -209,7 +209,7 @@ export function Project(props) {
     setLoading(true);
 		setBtnDeleteProjectDisabled(true);
     const request = {...project};
-    const response = await fetchApi("api/api/project", {
+    const response = await fetchApi("api/project", {
       method: "PUT",
       headers: {
         "Content-Type": "application/json"

--- a/Binner/Binner.Web/ClientApp/src/pages/Search.js
+++ b/Binner/Binner.Web/ClientApp/src/pages/Search.js
@@ -282,7 +282,7 @@ export function Search(props) {
             {showPartNotFound && 
               <span><Icon name="warning sign" color="yellow" />
               <Trans i18nKey="page.search.searchNotFound">
-                No resuts found in inventory. Do you want to <Link to={`/inventory/add/${keyword}`}>Add</Link> it?
+                No resuts found in inventory. Do you want to <Link to={`/inventory/add/${encodeURIComponent(keyword)}`}>Add</Link> it?
               </Trans>
               </span>}
           </div>

--- a/Binner/Binner.Web/ClientApp/src/pages/admin/Home.js
+++ b/Binner/Binner.Web/ClientApp/src/pages/admin/Home.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useTranslation, Trans } from "react-i18next";
-import { Segment, Breadcrumb, Icon } from "semantic-ui-react";
+import { Segment, Breadcrumb, Popup } from "semantic-ui-react";
 import { FormHeader } from "../../components/FormHeader";
 
 export const Admin = () => {
@@ -37,10 +37,18 @@ export const Admin = () => {
             <h1><span>{t('page.admin.systemInfo.title', "System Information")}</span></h1>
               <p>{t('page.admin.systemInfo.baseDescription', "Get information on your Binner installation.")}</p>
             </li>
-            <li /*onClick={() => navigate("/admin/updateParts")}*/ className="disabled">
+            <Popup 
+              hoverable
+              content={<p>
+                <Trans i18nKey="popup.makerSubscriptionRequired">
+                  Requires a Maker level subscription. <a href="https://binner.io/signup" target="_blank" rel="noreferrer">Click here</a> for details.
+                </Trans></p>} 
+              trigger={<li /*onClick={() => navigate("/admin/updateParts")}*/ className="disabled">
               <h1 className="maker"><span>Update Part Metadata</span></h1>
               <p>Refresh information from external APIs and choose which fields you would like to update.</p>
-						</li>
+						</li>} 
+            />
+            
 						{/*<li onClick={() => navigate("/admin/activateLicense")}>
               <h1><span>Activate License</span></h1>
               <p>If you have a paid subscription on <a href="https://binner.io" target="_blank" rel="noreferrer">Binner Cloud</a>, activate your license key to gain licensed features in your Binner installation.</p>

--- a/Binner/Binner.Web/ClientApp/src/pages/printing/Home.js
+++ b/Binner/Binner.Web/ClientApp/src/pages/printing/Home.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useTranslation, Trans } from "react-i18next";
-import { Segment, Breadcrumb, Icon } from "semantic-ui-react";
+import { Segment, Breadcrumb, Icon, Popup } from "semantic-ui-react";
 import { FormHeader } from "../../components/FormHeader";
 
 export const Printing = () => {
@@ -33,10 +33,17 @@ export const Printing = () => {
             <h1><span>{t('page.printing.printLabels.title', "Print Custom Labels")}</span></h1>
               <p>{t('page.printing.printLabels.baseDescription', "Print custom labels for any task.")}</p>
             </li>
-            <li /*onClick={() => navigate("/printing/bulkprint")}*/ className="disabled">
-            	<h1 className="maker"><span>{t('page.printing.bulkprint.title', "Bulk Print")}</span></h1>
-              <p>{t('page.printing.bulkprint.baseDescription', "Batch print labels for parts.")}</p>
-            </li>
+            <Popup 
+              hoverable
+              content={<p>
+                <Trans i18nKey="popup.makerSubscriptionRequired">
+                  Requires a Maker level subscription. <a href="https://binner.io/signup" target="_blank" rel="noreferrer">Click here</a> for details.
+                </Trans></p>} 
+              trigger={<li /*onClick={() => navigate("/printing/bulkprint")}*/ className="disabled">
+            	  <h1 className="maker"><span>{t('page.printing.bulkprint.title', "Bulk Print")}</span></h1>
+                <p>{t('page.printing.bulkprint.baseDescription', "Batch print labels for parts.")}</p>
+              </li>} 
+            />
           </ul>
         </div>
       </Segment>

--- a/Binner/Data/Binner.Data.Migrations.MySql/Migrations/20230521232243_AddCustomPartFields.Designer.cs
+++ b/Binner/Data/Binner.Data.Migrations.MySql/Migrations/20230521232243_AddCustomPartFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Binner.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Binner.Data.Migrations.MySql.Migrations
 {
     [DbContext(typeof(BinnerContext))]
-    partial class BinnerContextModelSnapshot : ModelSnapshot
+    [Migration("20230521232243_AddCustomPartFields")]
+    partial class AddCustomPartFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Binner/Data/Binner.Data.Migrations.MySql/Migrations/20230521232243_AddCustomPartFields.cs
+++ b/Binner/Data/Binner.Data.Migrations.MySql/Migrations/20230521232243_AddCustomPartFields.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Binner.Data.Migrations.MySql.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCustomPartFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ExtensionValue1",
+                schema: "dbo",
+                table: "Parts",
+                type: "longtext",
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ExtensionValue2",
+                schema: "dbo",
+                table: "Parts",
+                type: "longtext",
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AddColumn<string>(
+                name: "FootprintName",
+                schema: "dbo",
+                table: "Parts",
+                type: "longtext",
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AddColumn<string>(
+                name: "SymbolName",
+                schema: "dbo",
+                table: "Parts",
+                type: "longtext",
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ExtensionValue1",
+                schema: "dbo",
+                table: "Parts");
+
+            migrationBuilder.DropColumn(
+                name: "ExtensionValue2",
+                schema: "dbo",
+                table: "Parts");
+
+            migrationBuilder.DropColumn(
+                name: "FootprintName",
+                schema: "dbo",
+                table: "Parts");
+
+            migrationBuilder.DropColumn(
+                name: "SymbolName",
+                schema: "dbo",
+                table: "Parts");
+        }
+    }
+}

--- a/Binner/Data/Binner.Data.Migrations.Postgresql/Migrations/20230521232227_AddCustomPartFields.Designer.cs
+++ b/Binner/Data/Binner.Data.Migrations.Postgresql/Migrations/20230521232227_AddCustomPartFields.Designer.cs
@@ -3,58 +3,66 @@ using System;
 using Binner.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace Binner.Data.Migrations.MySql.Migrations
+namespace Binner.Data.Migrations.Postgresql.Migrations
 {
     [DbContext(typeof(BinnerContext))]
-    partial class BinnerContextModelSnapshot : ModelSnapshot
+    [Migration("20230521232227_AddCustomPartFields")]
+    partial class AddCustomPartFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasDefaultSchema("dbo")
                 .HasAnnotation("ProductVersion", "7.0.4")
-                .HasAnnotation("Relational:MaxIdentifierLength", 64);
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
+
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("Binner.Data.Model.Label", b =>
                 {
                     b.Property<int>("LabelId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("LabelId"));
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<bool>("IsPartLabelTemplate")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<int>("LabelTemplateId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Template")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("LabelId");
 
@@ -67,63 +75,65 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<int>("LabelTemplateId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("LabelTemplateId"));
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Description")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int>("Dpi")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("DriverHeight")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("DriverName")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int>("DriverWidth")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("ExtraData")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("Height")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int>("LabelCount")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("LabelPaperSource")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Margin")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Width")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.HasKey("LabelTemplateId");
 
@@ -134,22 +144,22 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<string>("Provider")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("AccessToken")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateExpiresUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<long>("Ip")
@@ -158,13 +168,13 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasDefaultValue(0L);
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("RefreshToken")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("Provider");
 
@@ -177,31 +187,33 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<int>("OAuthRequestId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("OAuthRequestId"));
 
                     b.Property<string>("AuthorizationCode")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<bool>("AuthorizationReceived")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("tinyint(1)")
+                        .HasColumnType("boolean")
                         .HasDefaultValue(false);
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Error")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("ErrorDescription")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<long>("Ip")
                         .ValueGeneratedOnAdd()
@@ -209,20 +221,20 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasDefaultValue(0L);
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Provider")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<Guid>("RequestId")
-                        .HasColumnType("char(36)");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("ReturnToUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("OAuthRequestId");
 
@@ -235,19 +247,21 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<int>("OrganizationId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("OrganizationId"));
 
                     b.Property<DateTime>("DateCreatedUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("DateModifiedUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Description")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.HasKey("OrganizationId");
 
@@ -260,94 +274,96 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("PartId"));
+
                     b.Property<string>("ArrowPartNumber")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("BinNumber")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("text");
 
                     b.Property<string>("BinNumber2")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("text");
 
                     b.Property<decimal>("Cost")
                         .HasColumnType("decimal(18,4)");
 
                     b.Property<string>("Currency")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("DatasheetUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Description")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("text");
 
                     b.Property<string>("DigiKeyPartNumber")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ExtensionValue1")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("ExtensionValue2")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("FootprintName")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("ImageUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("Keywords")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Location")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("text");
 
                     b.Property<int>("LowStockThreshold")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("LowestCostSupplier")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("LowestCostSupplierUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("Manufacturer")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ManufacturerPartNumber")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("text");
 
                     b.Property<int>("MountingTypeId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("MouserPartNumber")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("text");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("PackageType")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("PartNumber")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<long>("PartTypeId")
                         .HasColumnType("bigint");
 
                     b.Property<string>("ProductUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<long?>("ProjectId")
                         .HasColumnType("bigint");
@@ -356,10 +372,10 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasColumnType("bigint");
 
                     b.Property<string>("SymbolName")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("PartId");
 
@@ -398,45 +414,47 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("PartSupplierId"));
+
                     b.Property<decimal?>("Cost")
                         .HasColumnType("decimal(18,4)");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("ImageUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int>("MinimumOrderQuantity")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Name")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<long>("PartId")
                         .HasColumnType("bigint");
 
                     b.Property<string>("ProductUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int>("QuantityAvailable")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("SupplierPartNumber")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("PartSupplierId");
 
@@ -453,30 +471,32 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("PartTypeId"));
+
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Icon")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("text");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<long?>("ParentPartTypeId")
                         .HasColumnType("bigint");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("PartTypeId");
 
@@ -495,39 +515,41 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("PcbId"));
+
                     b.Property<double>("Cost")
-                        .HasColumnType("double");
+                        .HasColumnType("double precision");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Description")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("LastSerialNumber")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("SerialNumberFormat")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("PcbId");
 
@@ -542,24 +564,26 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("PcbStoredFileAssignmentId"));
+
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Name")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("Notes")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<long>("PcbId")
                         .HasColumnType("bigint");
@@ -568,7 +592,7 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasColumnType("bigint");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("PcbStoredFileAssignmentId");
 
@@ -587,36 +611,38 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("ProjectId"));
+
                     b.Property<int>("Color")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Description")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("Location")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Notes")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("ProjectId");
 
@@ -633,36 +659,38 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("ProjectPartAssignmentId"));
+
                     b.Property<double>("Cost")
-                        .HasColumnType("double");
+                        .HasColumnType("double precision");
 
                     b.Property<string>("Currency")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("CustomDescription")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Notes")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<long?>("PartId")
                         .HasColumnType("bigint");
 
                     b.Property<string>("PartName")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<long?>("PcbId")
                         .HasColumnType("bigint");
@@ -671,19 +699,19 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasColumnType("bigint");
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("QuantityAvailable")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("ReferenceId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("SchematicReferenceId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("ProjectPartAssignmentId");
 
@@ -702,18 +730,20 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("ProjectPcbAssignmentId"));
+
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<long>("PcbId")
                         .HasColumnType("bigint");
@@ -722,7 +752,7 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasColumnType("bigint");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("ProjectPcbAssignmentId");
 
@@ -741,39 +771,41 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("ProjectPcbProduceHistoryId"));
+
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("PartsConsumed")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<double>("PcbCost")
-                        .HasColumnType("double");
+                        .HasColumnType("double precision");
 
                     b.Property<long?>("PcbId")
                         .HasColumnType("bigint");
 
                     b.Property<int>("PcbQuantity")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<long>("ProjectProduceHistoryId")
                         .HasColumnType("bigint");
 
                     b.Property<string>("SerialNumber")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("ProjectPcbProduceHistoryId");
 
@@ -792,33 +824,35 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("ProjectProduceHistoryId"));
+
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("PartsConsumed")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<bool>("ProduceUnassociated")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<long>("ProjectId")
                         .HasColumnType("bigint");
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("ProjectProduceHistoryId");
 
@@ -835,32 +869,34 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("StoredFileId"));
+
                     b.Property<int>("Crc32")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<int>("FileLength")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("FileName")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("OriginalFileName")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<long?>("PartId")
                         .HasColumnType("bigint");
@@ -869,13 +905,13 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasColumnType("bigint");
 
                     b.Property<int>("RecordType")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("StoredFileType")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("StoredFileId");
 
@@ -890,36 +926,38 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<int>("UserId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("UserId"));
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime?>("DateEmailConfirmedUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DateLastActiveUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DateLastLoginUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DateLockedUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("EmailAddress")
                         .IsRequired()
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("text");
 
                     b.Property<string>("EmailConfirmationToken")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<long>("EmailConfirmedIp")
                         .ValueGeneratedOnAdd()
@@ -932,13 +970,13 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasDefaultValue(0L);
 
                     b.Property<bool>("IsAdmin")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsEmailConfirmed")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsEmailSubscribed")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<long>("LastSetPasswordIp")
                         .ValueGeneratedOnAdd()
@@ -946,30 +984,30 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasDefaultValue(0L);
 
                     b.Property<string>("LocaleCurrency")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("LocaleLanguage")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("text");
 
                     b.Property<int>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("PasswordHash")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("PhoneNumber")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("text");
 
                     b.Property<byte[]>("ProfileImage")
-                        .HasColumnType("longblob");
+                        .HasColumnType("bytea");
 
                     b.Property<double?>("ReCaptchaScore")
-                        .HasColumnType("double");
+                        .HasColumnType("double precision");
 
                     b.HasKey("UserId");
 
@@ -986,87 +1024,89 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<int>("UserIntegrationConfigurationId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("UserIntegrationConfigurationId"));
 
                     b.Property<string>("ArrowApiKey")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("ArrowApiUrl")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<bool>("ArrowEnabled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("ArrowUsername")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("DigiKeyApiUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("DigiKeyClientId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("DigiKeyClientSecret")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<bool>("DigiKeyEnabled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("DigiKeyOAuthPostbackUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("MouserApiUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("MouserCartApiKey")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<bool>("MouserEnabled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("MouserOrderApiKey")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("MouserSearchApiKey")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("OctopartClientId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("OctopartClientSecret")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<bool>("OctopartEnabled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("SwarmApiKey")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("SwarmApiUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<bool>("SwarmEnabled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<TimeSpan?>("SwarmTimeout")
-                        .HasColumnType("time(6)");
+                        .HasColumnType("interval");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("UserIntegrationConfigurationId");
 
@@ -1079,23 +1119,25 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<int>("UserLoginHistoryId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("UserLoginHistoryId"));
 
                     b.Property<bool>("CanLogin")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("EmailAddress")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<long>("Ip")
                         .ValueGeneratedOnAdd()
@@ -1103,19 +1145,19 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasDefaultValue(0L);
 
                     b.Property<bool>("IsSuccessful")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("Message")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<double?>("ReCaptchaScore")
-                        .HasColumnType("double");
+                        .HasColumnType("double precision");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("UserLoginHistoryId");
 
@@ -1128,37 +1170,39 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<int>("UserPrinterConfigurationId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("UserPrinterConfigurationId"));
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("PartLabelName")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int>("PartLabelSource")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("PrinterName")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("RemoteAddressUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("UserPrinterConfigurationId");
 
@@ -1171,75 +1215,77 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<int>("UserPrinterTemplateConfigurationId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("UserPrinterTemplateConfigurationId"));
 
                     b.Property<bool>("AutoSize")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("Barcode")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("Color")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("Content")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("FontName")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int>("FontSize")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("Label")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("Line")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<bool>("LowerCase")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<int>("MarginBottom")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("MarginLeft")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("MarginRight")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("MarginTop")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("Position")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("Rotate")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<bool>("UpperCase")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int>("UserPrinterConfigurationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("UserPrinterTemplateConfigurationId");
 
@@ -1254,23 +1300,25 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<int>("UserTokenId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("UserTokenId"));
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime?>("DateExpiredUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime?>("DateRevokedUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("Ip")
                         .ValueGeneratedOnAdd()
@@ -1278,20 +1326,20 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasDefaultValue(0L);
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("ReplacedByToken")
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<string>("Token")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("text");
 
                     b.Property<int>("TokenTypeId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("UserTokenId");
 

--- a/Binner/Data/Binner.Data.Migrations.Postgresql/Migrations/20230521232227_AddCustomPartFields.cs
+++ b/Binner/Data/Binner.Data.Migrations.Postgresql/Migrations/20230521232227_AddCustomPartFields.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Binner.Data.Migrations.Postgresql.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCustomPartFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ExtensionValue1",
+                schema: "dbo",
+                table: "Parts",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ExtensionValue2",
+                schema: "dbo",
+                table: "Parts",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "FootprintName",
+                schema: "dbo",
+                table: "Parts",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SymbolName",
+                schema: "dbo",
+                table: "Parts",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ExtensionValue1",
+                schema: "dbo",
+                table: "Parts");
+
+            migrationBuilder.DropColumn(
+                name: "ExtensionValue2",
+                schema: "dbo",
+                table: "Parts");
+
+            migrationBuilder.DropColumn(
+                name: "FootprintName",
+                schema: "dbo",
+                table: "Parts");
+
+            migrationBuilder.DropColumn(
+                name: "SymbolName",
+                schema: "dbo",
+                table: "Parts");
+        }
+    }
+}

--- a/Binner/Data/Binner.Data.Migrations.Postgresql/Migrations/BinnerContextModelSnapshot.cs
+++ b/Binner/Data/Binner.Data.Migrations.Postgresql/Migrations/BinnerContextModelSnapshot.cs
@@ -307,6 +307,15 @@ namespace Binner.Data.Migrations.Postgresql.Migrations
                     b.Property<string>("DigiKeyPartNumber")
                         .HasColumnType("text");
 
+                    b.Property<string>("ExtensionValue1")
+                        .HasColumnType("text");
+
+                    b.Property<string>("ExtensionValue2")
+                        .HasColumnType("text");
+
+                    b.Property<string>("FootprintName")
+                        .HasColumnType("text");
+
                     b.Property<string>("ImageUrl")
                         .HasColumnType("text");
 
@@ -358,6 +367,9 @@ namespace Binner.Data.Migrations.Postgresql.Migrations
 
                     b.Property<long>("Quantity")
                         .HasColumnType("bigint");
+
+                    b.Property<string>("SymbolName")
+                        .HasColumnType("text");
 
                     b.Property<int?>("UserId")
                         .HasColumnType("integer");

--- a/Binner/Data/Binner.Data.Migrations.SqlServer/Migrations/20230521232210_AddCustomPartFields.Designer.cs
+++ b/Binner/Data/Binner.Data.Migrations.SqlServer/Migrations/20230521232210_AddCustomPartFields.Designer.cs
@@ -3,22 +3,28 @@ using System;
 using Binner.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace Binner.Data.Migrations.MySql.Migrations
+namespace Binner.Data.Migrations.SqlServer.Migrations
 {
     [DbContext(typeof(BinnerContext))]
-    partial class BinnerContextModelSnapshot : ModelSnapshot
+    [Migration("20230521232210_AddCustomPartFields")]
+    partial class AddCustomPartFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasDefaultSchema("dbo")
                 .HasAnnotation("ProductVersion", "7.0.4")
-                .HasAnnotation("Relational:MaxIdentifierLength", 64);
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
             modelBuilder.Entity("Binner.Data.Model.Label", b =>
                 {
@@ -26,32 +32,34 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("LabelId"));
+
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<bool>("IsPartLabelTemplate")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<int>("LabelTemplateId")
                         .HasColumnType("int");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("OrganizationId")
                         .HasColumnType("int");
 
                     b.Property<string>("Template")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("UserId")
                         .HasColumnType("int");
@@ -69,18 +77,20 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("LabelTemplateId"));
+
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Description")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("Dpi")
                         .HasColumnType("int");
@@ -89,17 +99,17 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasColumnType("int");
 
                     b.Property<string>("DriverName")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("DriverWidth")
                         .HasColumnType("int");
 
                     b.Property<string>("ExtraData")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Height")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("LabelCount")
                         .HasColumnType("int");
@@ -109,11 +119,11 @@ namespace Binner.Data.Migrations.MySql.Migrations
 
                     b.Property<string>("Margin")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("OrganizationId")
                         .HasColumnType("int");
@@ -123,7 +133,7 @@ namespace Binner.Data.Migrations.MySql.Migrations
 
                     b.Property<string>("Width")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("LabelTemplateId");
 
@@ -134,22 +144,22 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<string>("Provider")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("nvarchar(128)");
 
                     b.Property<string>("AccessToken")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateExpiresUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<long>("Ip")
@@ -161,7 +171,7 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasColumnType("int");
 
                     b.Property<string>("RefreshToken")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("UserId")
                         .HasColumnType("int");
@@ -179,29 +189,31 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("OAuthRequestId"));
+
                     b.Property<string>("AuthorizationCode")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("AuthorizationReceived")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("tinyint(1)")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false);
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Error")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ErrorDescription")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<long>("Ip")
                         .ValueGeneratedOnAdd()
@@ -213,13 +225,13 @@ namespace Binner.Data.Migrations.MySql.Migrations
 
                     b.Property<string>("Provider")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<Guid>("RequestId")
-                        .HasColumnType("char(36)");
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("ReturnToUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("UserId")
                         .HasColumnType("int");
@@ -237,17 +249,19 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("OrganizationId"));
+
                     b.Property<DateTime>("DateCreatedUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime>("DateModifiedUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Description")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("OrganizationId");
 
@@ -260,94 +274,96 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("PartId"));
+
                     b.Property<string>("ArrowPartNumber")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("BinNumber")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("BinNumber2")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<decimal>("Cost")
                         .HasColumnType("decimal(18,4)");
 
                     b.Property<string>("Currency")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("DatasheetUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Description")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("DigiKeyPartNumber")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ExtensionValue1")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ExtensionValue2")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("FootprintName")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ImageUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Keywords")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Location")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<int>("LowStockThreshold")
                         .HasColumnType("int");
 
                     b.Property<string>("LowestCostSupplier")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("LowestCostSupplierUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Manufacturer")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ManufacturerPartNumber")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<int>("MountingTypeId")
                         .HasColumnType("int");
 
                     b.Property<string>("MouserPartNumber")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<int?>("OrganizationId")
                         .HasColumnType("int");
 
                     b.Property<string>("PackageType")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("PartNumber")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<long>("PartTypeId")
                         .HasColumnType("bigint");
 
                     b.Property<string>("ProductUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<long?>("ProjectId")
                         .HasColumnType("bigint");
@@ -356,7 +372,7 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasColumnType("bigint");
 
                     b.Property<string>("SymbolName")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("UserId")
                         .HasColumnType("int");
@@ -398,27 +414,29 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("PartSupplierId"));
+
                     b.Property<decimal?>("Cost")
                         .HasColumnType("decimal(18,4)");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("ImageUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("MinimumOrderQuantity")
                         .HasColumnType("int");
 
                     b.Property<string>("Name")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("OrganizationId")
                         .HasColumnType("int");
@@ -427,13 +445,13 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasColumnType("bigint");
 
                     b.Property<string>("ProductUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("QuantityAvailable")
                         .HasColumnType("int");
 
                     b.Property<string>("SupplierPartNumber")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("UserId")
                         .HasColumnType("int");
@@ -453,21 +471,23 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("PartTypeId"));
+
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Icon")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<int?>("OrganizationId")
                         .HasColumnType("int");
@@ -495,27 +515,29 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("PcbId"));
+
                     b.Property<double>("Cost")
-                        .HasColumnType("double");
+                        .HasColumnType("float");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Description")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("LastSerialNumber")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("OrganizationId")
                         .HasColumnType("int");
@@ -524,7 +546,7 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasColumnType("int");
 
                     b.Property<string>("SerialNumberFormat")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("UserId")
                         .HasColumnType("int");
@@ -542,21 +564,23 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("PcbStoredFileAssignmentId"));
+
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Name")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Notes")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("OrganizationId")
                         .HasColumnType("int");
@@ -587,30 +611,32 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("ProjectId"));
+
                     b.Property<int>("Color")
                         .HasColumnType("int");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Description")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Location")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Notes")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("OrganizationId")
                         .HasColumnType("int");
@@ -633,27 +659,29 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("ProjectPartAssignmentId"));
+
                     b.Property<double>("Cost")
-                        .HasColumnType("double");
+                        .HasColumnType("float");
 
                     b.Property<string>("Currency")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("CustomDescription")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Notes")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("OrganizationId")
                         .HasColumnType("int");
@@ -662,7 +690,7 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasColumnType("bigint");
 
                     b.Property<string>("PartName")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<long?>("PcbId")
                         .HasColumnType("bigint");
@@ -677,10 +705,10 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasColumnType("int");
 
                     b.Property<string>("ReferenceId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("SchematicReferenceId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("UserId")
                         .HasColumnType("int");
@@ -702,14 +730,16 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("ProjectPcbAssignmentId"));
+
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<int?>("OrganizationId")
@@ -741,14 +771,16 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("ProjectPcbProduceHistoryId"));
+
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<int?>("OrganizationId")
@@ -758,7 +790,7 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasColumnType("int");
 
                     b.Property<double>("PcbCost")
-                        .HasColumnType("double");
+                        .HasColumnType("float");
 
                     b.Property<long?>("PcbId")
                         .HasColumnType("bigint");
@@ -770,7 +802,7 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasColumnType("bigint");
 
                     b.Property<string>("SerialNumber")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("UserId")
                         .HasColumnType("int");
@@ -792,14 +824,16 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("ProjectProduceHistoryId"));
+
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<int?>("OrganizationId")
@@ -809,7 +843,7 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasColumnType("int");
 
                     b.Property<bool>("ProduceUnassociated")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<long>("ProjectId")
                         .HasColumnType("bigint");
@@ -835,17 +869,19 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("StoredFileId"));
+
                     b.Property<int>("Crc32")
                         .HasColumnType("int");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<int>("FileLength")
@@ -853,14 +889,14 @@ namespace Binner.Data.Migrations.MySql.Migrations
 
                     b.Property<string>("FileName")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("OrganizationId")
                         .HasColumnType("int");
 
                     b.Property<string>("OriginalFileName")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<long?>("PartId")
                         .HasColumnType("bigint");
@@ -892,34 +928,36 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("UserId"));
+
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime?>("DateEmailConfirmedUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("DateLastActiveUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("DateLastLoginUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("DateLockedUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("EmailAddress")
                         .IsRequired()
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("EmailConfirmationToken")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<long>("EmailConfirmedIp")
                         .ValueGeneratedOnAdd()
@@ -932,13 +970,13 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasDefaultValue(0L);
 
                     b.Property<bool>("IsAdmin")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsEmailConfirmed")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsEmailSubscribed")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<long>("LastSetPasswordIp")
                         .ValueGeneratedOnAdd()
@@ -946,30 +984,30 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasDefaultValue(0L);
 
                     b.Property<string>("LocaleCurrency")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("LocaleLanguage")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<int>("OrganizationId")
                         .HasColumnType("int");
 
                     b.Property<string>("PasswordHash")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("PhoneNumber")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<byte[]>("ProfileImage")
-                        .HasColumnType("longblob");
+                        .HasColumnType("varbinary(max)");
 
                     b.Property<double?>("ReCaptchaScore")
-                        .HasColumnType("double");
+                        .HasColumnType("float");
 
                     b.HasKey("UserId");
 
@@ -988,82 +1026,84 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("UserIntegrationConfigurationId"));
+
                     b.Property<string>("ArrowApiKey")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ArrowApiUrl")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("ArrowEnabled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<string>("ArrowUsername")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("DigiKeyApiUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("DigiKeyClientId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("DigiKeyClientSecret")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("DigiKeyEnabled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<string>("DigiKeyOAuthPostbackUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("MouserApiUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("MouserCartApiKey")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("MouserEnabled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<string>("MouserOrderApiKey")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("MouserSearchApiKey")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("OctopartClientId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("OctopartClientSecret")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("OctopartEnabled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<int?>("OrganizationId")
                         .HasColumnType("int");
 
                     b.Property<string>("SwarmApiKey")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("SwarmApiUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("SwarmEnabled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<TimeSpan?>("SwarmTimeout")
-                        .HasColumnType("time(6)");
+                        .HasColumnType("time");
 
                     b.Property<int?>("UserId")
                         .HasColumnType("int");
@@ -1081,21 +1121,23 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("UserLoginHistoryId"));
+
                     b.Property<bool>("CanLogin")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("EmailAddress")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<long>("Ip")
                         .ValueGeneratedOnAdd()
@@ -1103,16 +1145,16 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasDefaultValue(0L);
 
                     b.Property<bool>("IsSuccessful")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Message")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("OrganizationId")
                         .HasColumnType("int");
 
                     b.Property<double?>("ReCaptchaScore")
-                        .HasColumnType("double");
+                        .HasColumnType("float");
 
                     b.Property<int?>("UserId")
                         .HasColumnType("int");
@@ -1130,14 +1172,16 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("UserPrinterConfigurationId"));
+
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<int?>("OrganizationId")
@@ -1145,17 +1189,17 @@ namespace Binner.Data.Migrations.MySql.Migrations
 
                     b.Property<string>("PartLabelName")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("PartLabelSource")
                         .HasColumnType("int");
 
                     b.Property<string>("PrinterName")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("RemoteAddressUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("UserId")
                         .HasColumnType("int");
@@ -1173,31 +1217,33 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("UserPrinterTemplateConfigurationId"));
+
                     b.Property<bool>("AutoSize")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("Barcode")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Color")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Content")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("FontName")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("FontSize")
                         .HasColumnType("int");
@@ -1209,7 +1255,7 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasColumnType("int");
 
                     b.Property<bool>("LowerCase")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<int>("MarginBottom")
                         .HasColumnType("int");
@@ -1233,7 +1279,7 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasColumnType("int");
 
                     b.Property<bool>("UpperCase")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("bit");
 
                     b.Property<int?>("UserId")
                         .HasColumnType("int");
@@ -1256,21 +1302,23 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("UserTokenId"));
+
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime?>("DateExpiredUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("datetime2")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime?>("DateRevokedUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("datetime2");
 
                     b.Property<long>("Ip")
                         .ValueGeneratedOnAdd()
@@ -1281,11 +1329,11 @@ namespace Binner.Data.Migrations.MySql.Migrations
                         .HasColumnType("int");
 
                     b.Property<string>("ReplacedByToken")
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Token")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("TokenTypeId")
                         .HasColumnType("int");

--- a/Binner/Data/Binner.Data.Migrations.SqlServer/Migrations/20230521232210_AddCustomPartFields.cs
+++ b/Binner/Data/Binner.Data.Migrations.SqlServer/Migrations/20230521232210_AddCustomPartFields.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Binner.Data.Migrations.SqlServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCustomPartFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ExtensionValue1",
+                schema: "dbo",
+                table: "Parts",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ExtensionValue2",
+                schema: "dbo",
+                table: "Parts",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "FootprintName",
+                schema: "dbo",
+                table: "Parts",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SymbolName",
+                schema: "dbo",
+                table: "Parts",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ExtensionValue1",
+                schema: "dbo",
+                table: "Parts");
+
+            migrationBuilder.DropColumn(
+                name: "ExtensionValue2",
+                schema: "dbo",
+                table: "Parts");
+
+            migrationBuilder.DropColumn(
+                name: "FootprintName",
+                schema: "dbo",
+                table: "Parts");
+
+            migrationBuilder.DropColumn(
+                name: "SymbolName",
+                schema: "dbo",
+                table: "Parts");
+        }
+    }
+}

--- a/Binner/Data/Binner.Data.Migrations.SqlServer/Migrations/BinnerContextModelSnapshot.cs
+++ b/Binner/Data/Binner.Data.Migrations.SqlServer/Migrations/BinnerContextModelSnapshot.cs
@@ -307,6 +307,15 @@ namespace Binner.Data.Migrations.SqlServer.Migrations
                     b.Property<string>("DigiKeyPartNumber")
                         .HasColumnType("nvarchar(450)");
 
+                    b.Property<string>("ExtensionValue1")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("ExtensionValue2")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("FootprintName")
+                        .HasColumnType("nvarchar(max)");
+
                     b.Property<string>("ImageUrl")
                         .HasColumnType("nvarchar(max)");
 
@@ -358,6 +367,9 @@ namespace Binner.Data.Migrations.SqlServer.Migrations
 
                     b.Property<long>("Quantity")
                         .HasColumnType("bigint");
+
+                    b.Property<string>("SymbolName")
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("UserId")
                         .HasColumnType("int");

--- a/Binner/Data/Binner.Data.Migrations.Sqlite/Migrations/20230521232152_AddCustomPartFields.Designer.cs
+++ b/Binner/Data/Binner.Data.Migrations.Sqlite/Migrations/20230521232152_AddCustomPartFields.Designer.cs
@@ -3,58 +3,60 @@ using System;
 using Binner.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace Binner.Data.Migrations.MySql.Migrations
+namespace Binner.Data.Migrations.Sqlite.Migrations
 {
     [DbContext(typeof(BinnerContext))]
-    partial class BinnerContextModelSnapshot : ModelSnapshot
+    [Migration("20230521232152_AddCustomPartFields")]
+    partial class AddCustomPartFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasDefaultSchema("dbo")
-                .HasAnnotation("ProductVersion", "7.0.4")
-                .HasAnnotation("Relational:MaxIdentifierLength", 64);
+                .HasAnnotation("ProductVersion", "7.0.4");
 
             modelBuilder.Entity("Binner.Data.Model.Label", b =>
                 {
                     b.Property<int>("LabelId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<bool>("IsPartLabelTemplate")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("LabelTemplateId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Template")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("LabelId");
 
@@ -67,63 +69,63 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<int>("LabelTemplateId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Description")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Dpi")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("DriverHeight")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("DriverName")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("DriverWidth")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ExtraData")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Height")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("LabelCount")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("LabelPaperSource")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Margin")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Width")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("LabelTemplateId");
 
@@ -134,37 +136,37 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<string>("Provider")
                         .HasMaxLength(128)
-                        .HasColumnType("varchar(128)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("AccessToken")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateExpiresUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<long>("Ip")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(0L);
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("RefreshToken")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Provider");
 
@@ -177,52 +179,52 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<int>("OAuthRequestId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("AuthorizationCode")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("AuthorizationReceived")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("tinyint(1)")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(false);
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Error")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ErrorDescription")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("Ip")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(0L);
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Provider")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("RequestId")
-                        .HasColumnType("char(36)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ReturnToUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("OAuthRequestId");
 
@@ -235,19 +237,19 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<int>("OrganizationId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("DateCreatedUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateModifiedUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Description")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("OrganizationId");
 
@@ -258,108 +260,108 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<long>("PartId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ArrowPartNumber")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("BinNumber")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("BinNumber2")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("TEXT");
 
-                    b.Property<decimal>("Cost")
+                    b.Property<double>("Cost")
                         .HasColumnType("decimal(18,4)");
 
                     b.Property<string>("Currency")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DatasheetUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Description")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DigiKeyPartNumber")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ExtensionValue1")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ExtensionValue2")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("FootprintName")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ImageUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Keywords")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Location")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("LowStockThreshold")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("LowestCostSupplier")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("LowestCostSupplierUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Manufacturer")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ManufacturerPartNumber")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("MountingTypeId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("MouserPartNumber")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("PackageType")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("PartNumber")
                         .HasMaxLength(64)
-                        .HasColumnType("varchar(64)");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("PartTypeId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ProductUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<long?>("ProjectId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("Quantity")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SymbolName")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("PartId");
 
@@ -396,47 +398,47 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<long>("PartSupplierId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
-                    b.Property<decimal?>("Cost")
+                    b.Property<double?>("Cost")
                         .HasColumnType("decimal(18,4)");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("ImageUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("MinimumOrderQuantity")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Name")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("PartId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ProductUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("QuantityAvailable")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SupplierPartNumber")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("PartSupplierId");
 
@@ -451,32 +453,32 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<long>("PartTypeId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Icon")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long?>("ParentPartTypeId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("PartTypeId");
 
@@ -493,41 +495,41 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<long>("PcbId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<double>("Cost")
-                        .HasColumnType("double");
+                        .HasColumnType("REAL");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Description")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("LastSerialNumber")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SerialNumberFormat")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("PcbId");
 
@@ -540,35 +542,35 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<long>("PcbStoredFileAssignmentId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Name")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Notes")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("PcbId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("StoredFileId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("PcbStoredFileAssignmentId");
 
@@ -585,38 +587,38 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<long>("ProjectId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("Color")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Description")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Location")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Notes")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("ProjectId");
 
@@ -631,59 +633,59 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<long>("ProjectPartAssignmentId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<double>("Cost")
-                        .HasColumnType("double");
+                        .HasColumnType("REAL");
 
                     b.Property<string>("Currency")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("CustomDescription")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("Notes")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long?>("PartId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("PartName")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<long?>("PcbId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("ProjectId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("QuantityAvailable")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ReferenceId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SchematicReferenceId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("ProjectPartAssignmentId");
 
@@ -700,29 +702,29 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<long>("ProjectPcbAssignmentId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("PcbId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("ProjectId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("ProjectPcbAssignmentId");
 
@@ -739,41 +741,41 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<long>("ProjectPcbProduceHistoryId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("PartsConsumed")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<double>("PcbCost")
-                        .HasColumnType("double");
+                        .HasColumnType("REAL");
 
                     b.Property<long?>("PcbId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("PcbQuantity")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("ProjectProduceHistoryId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SerialNumber")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("ProjectPcbProduceHistoryId");
 
@@ -790,35 +792,35 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<long>("ProjectProduceHistoryId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("PartsConsumed")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("ProduceUnassociated")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("ProjectId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("ProjectProduceHistoryId");
 
@@ -833,49 +835,49 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<long>("StoredFileId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("Crc32")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<int>("FileLength")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("FileName")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("OriginalFileName")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<long?>("PartId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long?>("RecordId")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("RecordType")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("StoredFileType")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("StoredFileId");
 
@@ -890,86 +892,86 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<int>("UserId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime?>("DateEmailConfirmedUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("DateLastActiveUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("DateLastLoginUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("DateLockedUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("EmailAddress")
                         .IsRequired()
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("EmailConfirmationToken")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("EmailConfirmedIp")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(0L);
 
                     b.Property<long>("Ip")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(0L);
 
                     b.Property<bool>("IsAdmin")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("IsEmailConfirmed")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("IsEmailSubscribed")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("LastSetPasswordIp")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(0L);
 
                     b.Property<string>("LocaleCurrency")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("LocaleLanguage")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("PasswordHash")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("PhoneNumber")
-                        .HasColumnType("varchar(255)");
+                        .HasColumnType("TEXT");
 
                     b.Property<byte[]>("ProfileImage")
-                        .HasColumnType("longblob");
+                        .HasColumnType("BLOB");
 
                     b.Property<double?>("ReCaptchaScore")
-                        .HasColumnType("double");
+                        .HasColumnType("REAL");
 
                     b.HasKey("UserId");
 
@@ -986,87 +988,87 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<int>("UserIntegrationConfigurationId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ArrowApiKey")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ArrowApiUrl")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("ArrowEnabled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ArrowUsername")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("DigiKeyApiUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DigiKeyClientId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DigiKeyClientSecret")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("DigiKeyEnabled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("DigiKeyOAuthPostbackUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("MouserApiUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("MouserCartApiKey")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("MouserEnabled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("MouserOrderApiKey")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("MouserSearchApiKey")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("OctopartClientId")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("OctopartClientSecret")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("OctopartEnabled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("SwarmApiKey")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SwarmApiUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("SwarmEnabled")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<TimeSpan?>("SwarmTimeout")
-                        .HasColumnType("time(6)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("UserIntegrationConfigurationId");
 
@@ -1079,43 +1081,43 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<int>("UserLoginHistoryId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("CanLogin")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("EmailAddress")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("Ip")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(0L);
 
                     b.Property<bool>("IsSuccessful")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Message")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<double?>("ReCaptchaScore")
-                        .HasColumnType("double");
+                        .HasColumnType("REAL");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("UserLoginHistoryId");
 
@@ -1128,37 +1130,37 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<int>("UserPrinterConfigurationId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("PartLabelName")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("PartLabelSource")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("PrinterName")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("RemoteAddressUrl")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("UserPrinterConfigurationId");
 
@@ -1171,75 +1173,75 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<int>("UserPrinterTemplateConfigurationId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("AutoSize")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("Barcode")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Color")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Content")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<string>("FontName")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("FontSize")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("Label")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("Line")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("LowerCase")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("MarginBottom")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("MarginLeft")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("MarginRight")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("MarginTop")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("Position")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("Rotate")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("UpperCase")
-                        .HasColumnType("tinyint(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("UserPrinterConfigurationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("UserPrinterTemplateConfigurationId");
 
@@ -1254,44 +1256,44 @@ namespace Binner.Data.Migrations.MySql.Migrations
                 {
                     b.Property<int>("UserTokenId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime>("DateCreatedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime?>("DateExpiredUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateModifiedUtc")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime(6)")
+                        .HasColumnType("TEXT")
                         .HasDefaultValueSql("getutcdate()");
 
                     b.Property<DateTime?>("DateRevokedUtc")
-                        .HasColumnType("datetime(6)");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("Ip")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint")
+                        .HasColumnType("INTEGER")
                         .HasDefaultValue(0L);
 
                     b.Property<int?>("OrganizationId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ReplacedByToken")
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Token")
                         .IsRequired()
-                        .HasColumnType("longtext");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("TokenTypeId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("UserTokenId");
 

--- a/Binner/Data/Binner.Data.Migrations.Sqlite/Migrations/20230521232152_AddCustomPartFields.cs
+++ b/Binner/Data/Binner.Data.Migrations.Sqlite/Migrations/20230521232152_AddCustomPartFields.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Binner.Data.Migrations.Sqlite.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCustomPartFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ExtensionValue1",
+                schema: "dbo",
+                table: "Parts",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ExtensionValue2",
+                schema: "dbo",
+                table: "Parts",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "FootprintName",
+                schema: "dbo",
+                table: "Parts",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SymbolName",
+                schema: "dbo",
+                table: "Parts",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ExtensionValue1",
+                schema: "dbo",
+                table: "Parts");
+
+            migrationBuilder.DropColumn(
+                name: "ExtensionValue2",
+                schema: "dbo",
+                table: "Parts");
+
+            migrationBuilder.DropColumn(
+                name: "FootprintName",
+                schema: "dbo",
+                table: "Parts");
+
+            migrationBuilder.DropColumn(
+                name: "SymbolName",
+                schema: "dbo",
+                table: "Parts");
+        }
+    }
+}

--- a/Binner/Data/Binner.Data.Migrations.Sqlite/Migrations/BinnerContextModelSnapshot.cs
+++ b/Binner/Data/Binner.Data.Migrations.Sqlite/Migrations/BinnerContextModelSnapshot.cs
@@ -293,6 +293,15 @@ namespace Binner.Data.Migrations.Sqlite.Migrations
                     b.Property<string>("DigiKeyPartNumber")
                         .HasColumnType("TEXT");
 
+                    b.Property<string>("ExtensionValue1")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("ExtensionValue2")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("FootprintName")
+                        .HasColumnType("TEXT");
+
                     b.Property<string>("ImageUrl")
                         .HasColumnType("TEXT");
 
@@ -344,6 +353,9 @@ namespace Binner.Data.Migrations.Sqlite.Migrations
 
                     b.Property<long>("Quantity")
                         .HasColumnType("INTEGER");
+
+                    b.Property<string>("SymbolName")
+                        .HasColumnType("TEXT");
 
                     b.Property<int?>("UserId")
                         .HasColumnType("INTEGER");

--- a/Binner/Data/Binner.Data.Model/Part.cs
+++ b/Binner/Data/Binner.Data.Model/Part.cs
@@ -7,7 +7,7 @@ namespace Binner.Data.Model
     /// <summary>
     /// A Part
     /// </summary>
-    public class Part 
+    public class Part
 #if INITIALCREATE
         : IEntity,
 #else
@@ -158,6 +158,26 @@ namespace Binner.Data.Model
         /// The manufacturer part number
         /// </summary>
         public string? ManufacturerPartNumber { get; set; }
+
+        /// <summary>
+        /// KiCad symbol name
+        /// </summary>
+        public string? SymbolName { get; set; }
+
+        /// <summary>
+        /// KiCad footprint name
+        /// </summary>
+        public string? FootprintName { get; set; }
+
+        /// <summary>
+        /// Extension value 1 (can be used to store custom information)
+        /// </summary>
+        public string? ExtensionValue1 { get; set; }
+
+        /// <summary>
+        /// Extension value 2 (can be used to store custom information)
+        /// </summary>
+        public string? ExtensionValue2 { get; set; }
 
         /// <summary>
         /// The date the record was created

--- a/Binner/Data/Binner.StorageProvider.EntityFrameworkCore/EntityFrameworkStorageProvider.cs
+++ b/Binner/Data/Binner.StorageProvider.EntityFrameworkCore/EntityFrameworkStorageProvider.cs
@@ -163,7 +163,11 @@ PartNumber = '{keywords}'
  OR Keywords = '{keywords}'
  OR Location = '{keywords}'
  OR BinNumber = '{keywords}'
- OR BinNumber2 = '{keywords}')
+ OR BinNumber2 = '{keywords}'
+ OR SymbolName = '{keywords}'
+ OR FootprintName = '{keywords}'
+ OR ExtensionValue1 = '{keywords}'
+ OR ExtensionValue2 = '{keywords}')
 ),
 PartsBeginsWith (PartId, Rank) AS
 (
@@ -176,7 +180,11 @@ PartNumber LIKE '{keywords}'  + '%'
  OR Keywords LIKE '{keywords}' + '%'
  OR Location LIKE '{keywords}' + '%'
  OR BinNumber LIKE '{keywords}' + '%'
- OR BinNumber2 LIKE '{keywords}'+ '%')
+ OR BinNumber2 LIKE '{keywords}'+ '%'
+ OR SymbolName LIKE '{keywords}' + '%'
+ OR FootprintName LIKE '{keywords}' + '%'
+ OR ExtensionValue1 LIKE '{keywords}' + '%'
+ OR ExtensionValue2 LIKE '{keywords}' + '%')
 ),
 PartsAny (PartId, Rank) AS
 (
@@ -189,7 +197,11 @@ PartNumber LIKE '%' + '{keywords}' + '%'
  OR Keywords LIKE '%' + '{keywords}' + '%'
  OR Location LIKE '%' + '{keywords}' + '%'
  OR BinNumber LIKE '%' + '{keywords}' + '%'
- OR BinNumber2 LIKE '%' + '{keywords}' + '%')
+ OR BinNumber2 LIKE '%' + '{keywords}' + '%'
+ OR SymbolName LIKE '%' + '{keywords}' + '%'
+ OR FootprintName LIKE '%' + '{keywords}' + '%'
+ OR ExtensionValue1 LIKE '%' + '{keywords}' + '%'
+ OR ExtensionValue2 LIKE '%' + '{keywords}' + '%')
 ),
 PartsMerged (PartId, Rank) AS
 (
@@ -221,7 +233,11 @@ PartNumber = '{keywords}'
  OR Keywords = '{keywords}'
  OR Location = '{keywords}'
  OR BinNumber = '{keywords}'
- OR BinNumber2 = '{keywords}')
+ OR BinNumber2 = '{keywords}'
+ OR SymbolName = '{keywords}'
+ OR FootprintName = '{keywords}'
+ OR ExtensionValue1 = '{keywords}'
+ OR ExtensionValue2 = '{keywords}')
 ),
 PartsBeginsWith (PartId, Rank) AS
 (
@@ -234,7 +250,11 @@ PartNumber LIKE '{keywords}' || '%'
  OR Keywords LIKE '{keywords}' || '%'
  OR Location LIKE '{keywords}' || '%'
  OR BinNumber LIKE '{keywords}' || '%'
- OR BinNumber2 LIKE '{keywords}' || '%')
+ OR BinNumber2 LIKE '{keywords}' || '%'
+ OR SymbolName LIKE '{keywords}' || '%'
+ OR FootprintName LIKE '{keywords}' || '%'
+ OR ExtensionValue1 LIKE '{keywords}' || '%'
+ OR ExtensionValue2 LIKE '{keywords}' || '%')
 ),
 PartsAny (PartId, Rank) AS
 (
@@ -247,7 +267,11 @@ PartNumber LIKE '%' + '{keywords}' || '%'
  OR Keywords LIKE '%' || '{keywords}' || '%'
  OR Location LIKE '%' || '{keywords}' || '%'
  OR BinNumber LIKE '%' || '{keywords}' || '%'
- OR BinNumber2 LIKE '%' || '{keywords}' || '%')
+ OR BinNumber2 LIKE '%' || '{keywords}' || '%'
+ OR SymbolName LIKE '%' || '{keywords}' || '%'
+ OR FootprintName LIKE '%' || '{keywords}' || '%'
+ OR ExtensionValue1 LIKE '%' || '{keywords}' || '%'
+ OR ExtensionValue2 LIKE '%' || '{keywords}' || '%')
 ),
 PartsMerged (PartId, Rank) AS
 (
@@ -279,7 +303,11 @@ PartNumber = '{keywords}'
  OR Keywords = '{keywords}'
  OR Location = '{keywords}'
  OR BinNumber = '{keywords}'
- OR BinNumber2 = '{keywords}')
+ OR BinNumber2 = '{keywords}'
+ OR SymbolName = '{keywords}'
+ OR FootprintName = '{keywords}'
+ OR ExtensionValue1 = '{keywords}'
+ OR ExtensionValue2 = '{keywords}')
 ),
 PartsBeginsWith (PartId, OrderRank) AS
 (
@@ -292,7 +320,11 @@ PartNumber LIKE CONCAT('{keywords}','%')
  OR Keywords LIKE CONCAT('{keywords}','%')
  OR Location LIKE CONCAT('{keywords}','%')
  OR BinNumber LIKE CONCAT('{keywords}','%')
- OR BinNumber2 LIKE CONCAT('{keywords}','%'))
+ OR BinNumber2 LIKE CONCAT('{keywords}','%')
+ OR SymbolName LIKE CONCAT('{keywords}','%')
+ OR FootprintName LIKE CONCAT('{keywords}','%')
+ OR ExtensionValue1 LIKE CONCAT('{keywords}','%')
+ OR ExtensionValue2 LIKE CONCAT('{keywords}','%'))
 ),
 PartsAny (PartId, OrderRank) AS
 (
@@ -305,7 +337,11 @@ PartNumber LIKE CONCAT('%','{keywords}','%')
  OR Keywords LIKE CONCAT('%','{keywords}','%')
  OR Location LIKE CONCAT('%','{keywords}','%')
  OR BinNumber LIKE CONCAT('%','{keywords}','%')
- OR BinNumber2 LIKE CONCAT('%','{keywords}','%'))
+ OR BinNumber2 LIKE CONCAT('%','{keywords}','%')
+ OR SymbolName LIKE CONCAT('%','{keywords}','%')
+ OR FootprintName LIKE CONCAT('%','{keywords}','%')
+ OR ExtensionValue1 LIKE CONCAT('%','{keywords}','%')
+ OR ExtensionValue2 LIKE CONCAT('%','{keywords}','%'))
 ),
 PartsMerged (PartId, OrderRank) AS
 (
@@ -338,7 +374,11 @@ OR ""Description"" ILIKE '{keywords}'
 OR ""Keywords"" ILIKE '{keywords}' 
 OR ""Location"" ILIKE '{keywords}' 
 OR ""BinNumber"" ILIKE '{keywords}' 
-OR ""BinNumber2"" ILIKE '{keywords}')
+OR ""BinNumber2"" ILIKE '{keywords}'
+OR ""SymbolName"" ILIKE '{keywords}'
+OR ""FootprintName"" ILIKE '{keywords}'
+OR ""ExtensionValue1"" ILIKE '{keywords}'
+OR ""ExtensionValue2"" ILIKE '{keywords}')
 ),
 ""PartsBeginsWith"" (""PartId"", ""Rank"") AS
 (
@@ -352,7 +392,11 @@ OR ""Description"" ILIKE CONCAT('{keywords}', '%')
 OR ""Keywords"" ILIKE CONCAT('{keywords}', '%')
 OR ""Location"" ILIKE CONCAT('{keywords}', '%')
 OR ""BinNumber"" ILIKE CONCAT('{keywords}', '%')
-OR ""BinNumber2"" ILIKE CONCAT('{keywords}', '%'))
+OR ""BinNumber2"" ILIKE CONCAT('{keywords}', '%')
+OR ""SymbolName"" ILIKE CONCAT('{keywords}', '%')
+OR ""FootprintName"" ILIKE CONCAT('{keywords}', '%')
+OR ""ExtensionValue1"" ILIKE CONCAT('{keywords}', '%')
+OR ""ExtensionValue2"" ILIKE CONCAT('{keywords}', '%'))
 ),
 ""PartsAny"" (""PartId"", ""Rank"") AS
 (
@@ -366,7 +410,11 @@ OR ""Description"" ILIKE CONCAT('%', '{keywords}', '%')
 OR ""Keywords"" ILIKE CONCAT('%', '{keywords}', '%')
 OR ""Location"" ILIKE CONCAT('%', '{keywords}', '%')
 OR ""BinNumber"" ILIKE CONCAT('%', '{keywords}', '%')
-OR ""BinNumber2"" ILIKE CONCAT('%', '{keywords}', '%'))
+OR ""BinNumber2"" ILIKE CONCAT('%', '{keywords}', '%')
+OR ""SymbolName"" ILIKE CONCAT('%', '{keywords}', '%')
+OR ""FootprintName"" ILIKE CONCAT('%', '{keywords}', '%')
+OR ""ExtensionValue1"" ILIKE CONCAT('%', '{keywords}', '%')
+OR ""ExtensionValue2"" ILIKE CONCAT('%', '{keywords}', '%'))
 ),
 ""PartsMerged"" (""PartId"", ""Rank"") AS
 (
@@ -1042,6 +1090,10 @@ INNER JOIN (
                     || EF.Functions.Like(x.BinNumber, '%' + request.Keyword + '%')
                     || EF.Functions.Like(x.BinNumber2, '%' + request.Keyword + '%')
                     || EF.Functions.Like(x.PartType.Name, '%' + request.Keyword + '%')
+                    || EF.Functions.Like(x.SymbolName, '%' + request.Keyword + '%')
+                    || EF.Functions.Like(x.FootprintName, '%' + request.Keyword + '%')
+                    || EF.Functions.Like(x.ExtensionValue1, '%' + request.Keyword + '%')
+                    || EF.Functions.Like(x.ExtensionValue2, '%' + request.Keyword + '%')
                 );
             }
 
@@ -1172,6 +1224,10 @@ INNER JOIN (
                 new (x => x.ProductUrl, x => x.ProductUrl),
                 new (x => x.ProjectId, x => x.ProjectId),
                 new (x => x.Quantity, x => x.Quantity),
+                new (x => x.SymbolName, x => x.SymbolName),
+                new (x => x.FootprintName, x => x.FootprintName),
+                new (x => x.ExtensionValue1, x => x.ExtensionValue1),
+                new (x => x.ExtensionValue2, x => x.ExtensionValue2),
                 // todo: migrate
                 // new (x => x.SwarmPartNumberManufacturerId, x => x.SwarmPartNumberManufacturerId),
                 new (x => x.UserId, x => x.UserId),

--- a/Binner/Library/Binner.Common/Configuration/ConfigurationValidator.cs
+++ b/Binner/Library/Binner.Common/Configuration/ConfigurationValidator.cs
@@ -44,12 +44,19 @@ namespace Binner.Common.Configuration
             }
             if (config.Integrations.Mouser.Enabled)
             {
-                if (string.IsNullOrEmpty(config.Integrations.Mouser.ApiKeys.SearchApiKey) || config.Integrations.Mouser.ApiKeys.SearchApiKey.SurroundedBy("@"))
+                if (!string.IsNullOrEmpty(config.Integrations.Mouser.ApiKeys.SearchApiKey) && config.Integrations.Mouser.ApiKeys.SearchApiKey.SurroundedBy("@"))
                     ConfigAssert("Integrations.Mouser.ApiKeys.SearchApiKey", config.Integrations.Mouser.ApiKeys.SearchApiKey);
-                if (string.IsNullOrEmpty(config.Integrations.Mouser.ApiKeys.OrderApiKey) || config.Integrations.Mouser.ApiKeys.OrderApiKey.SurroundedBy("@"))
+                if (!string.IsNullOrEmpty(config.Integrations.Mouser.ApiKeys.OrderApiKey) && config.Integrations.Mouser.ApiKeys.OrderApiKey.SurroundedBy("@"))
                     ConfigAssert("Integrations.Mouser.ApiKeys.OrderApiKey", config.Integrations.Mouser.ApiKeys.OrderApiKey);
-                if (string.IsNullOrEmpty(config.Integrations.Mouser.ApiKeys.CartApiKey) || config.Integrations.Mouser.ApiKeys.CartApiKey.SurroundedBy("@"))
+                if (!string.IsNullOrEmpty(config.Integrations.Mouser.ApiKeys.CartApiKey) && config.Integrations.Mouser.ApiKeys.CartApiKey.SurroundedBy("@"))
                     ConfigAssert("Integrations.Mouser.ApiKeys.CartApiKey", config.Integrations.Mouser.ApiKeys.CartApiKey);
+
+                if (string.IsNullOrEmpty(config.Integrations.Mouser.ApiKeys.SearchApiKey)
+                    && string.IsNullOrEmpty(config.Integrations.Mouser.ApiKeys.OrderApiKey)
+                    && string.IsNullOrEmpty(config.Integrations.Mouser.ApiKeys.CartApiKey))
+                {
+                    ConfigAssert("Integrations.Mouser.ApiKeys.SearchApiKey", config.Integrations.Mouser.ApiKeys.SearchApiKey, "At least one api key must be provided.");
+                }
             }
             if (config.Integrations.Arrow.Enabled)
             {

--- a/Binner/Library/Binner.Common/IO/Printing/LabelGenerator.cs
+++ b/Binner/Library/Binner.Common/IO/Printing/LabelGenerator.cs
@@ -157,6 +157,12 @@ namespace Binner.Common.IO.Printing
                         if (part.Keywords?.Any() == true)
                             text = string.Join(",", part.Keywords);
                         break;
+                    case "Quantity":
+                        text = part.GetPropertyValue<long>(propertyName).ToString();
+                        break;
+                    case "Cost":
+                        text = part.GetPropertyValue<double>(propertyName).ToString();
+                        break;
                     default:
                         text = part.GetPropertyValue<string>(propertyName);
                         break;

--- a/Binner/Library/Binner.Common/MappingProfiles/ModelCommon/PartProfile.cs
+++ b/Binner/Library/Binner.Common/MappingProfiles/ModelCommon/PartProfile.cs
@@ -38,6 +38,10 @@ namespace Binner.Common.MappingProfiles.ModelCommon
                 .ForMember(x => x.ProductUrl, options => options.MapFrom(x => x.ProductUrl))
                 .ForMember(x => x.ProjectId, options => options.MapFrom(x => x.ProjectId))
                 .ForMember(x => x.Quantity, options => options.MapFrom(x => x.Quantity))
+                .ForMember(x => x.SymbolName, options => options.MapFrom(x => x.SymbolName))
+                .ForMember(x => x.FootprintName, options => options.MapFrom(x => x.FootprintName))
+                .ForMember(x => x.ExtensionValue1, options => options.MapFrom(x => x.ExtensionValue1))
+                .ForMember(x => x.ExtensionValue2, options => options.MapFrom(x => x.ExtensionValue2))
                 .ForMember(x => x.MountingType, options => options.Ignore())
                 ;
 
@@ -68,6 +72,10 @@ namespace Binner.Common.MappingProfiles.ModelCommon
                 .ForMember(x => x.ProductUrl, options => options.MapFrom(x => x.ProductUrl))
                 .ForMember(x => x.ProjectId, options => options.MapFrom(x => x.ProjectId))
                 .ForMember(x => x.Quantity, options => options.MapFrom(x => x.Quantity))
+                .ForMember(x => x.SymbolName, options => options.MapFrom(x => x.SymbolName))
+                .ForMember(x => x.FootprintName, options => options.MapFrom(x => x.FootprintName))
+                .ForMember(x => x.ExtensionValue1, options => options.MapFrom(x => x.ExtensionValue1))
+                .ForMember(x => x.ExtensionValue2, options => options.MapFrom(x => x.ExtensionValue2))
                 .ForMember(x => x.DateCreatedUtc, options => options.Ignore())
                 .ForMember(x => x.KeywordsList, options => options.Ignore())
                 .ForMember(x => x.PartType, options => options.Ignore())
@@ -110,6 +118,10 @@ namespace Binner.Common.MappingProfiles.ModelCommon
                 .ForMember(x => x.ProjectId, options => options.MapFrom(x => x.ProjectId))
                 .ForMember(x => x.Quantity, options => options.MapFrom(x => x.Quantity))
                 .ForMember(x => x.DateCreatedUtc, options => options.MapFrom(x => x.DateCreatedUtc))
+                .ForMember(x => x.SymbolName, options => options.MapFrom(x => x.SymbolName))
+                .ForMember(x => x.FootprintName, options => options.MapFrom(x => x.FootprintName))
+                .ForMember(x => x.ExtensionValue1, options => options.MapFrom(x => x.ExtensionValue1))
+                .ForMember(x => x.ExtensionValue2, options => options.MapFrom(x => x.ExtensionValue2))
                 ;
 
             CreateMap<Part, DataModel.Part>()
@@ -140,6 +152,10 @@ namespace Binner.Common.MappingProfiles.ModelCommon
                 .ForMember(x => x.ProjectId, options => options.MapFrom(x => x.ProjectId))
                 .ForMember(x => x.Quantity, options => options.MapFrom(x => x.Quantity))
                 .ForMember(x => x.DateCreatedUtc, options => options.MapFrom(x => x.DateCreatedUtc))
+                .ForMember(x => x.SymbolName, options => options.MapFrom(x => x.SymbolName))
+                .ForMember(x => x.FootprintName, options => options.MapFrom(x => x.FootprintName))
+                .ForMember(x => x.ExtensionValue1, options => options.MapFrom(x => x.ExtensionValue1))
+                .ForMember(x => x.ExtensionValue2, options => options.MapFrom(x => x.ExtensionValue2))
                 .ForMember(x => x.PartSuppliers, options => options.Ignore())
                 .ForMember(x => x.PartType, options => options.Ignore())
                 .ForMember(x => x.Project, options => options.Ignore())

--- a/Binner/Library/Binner.Common/MappingProfiles/ModelCommon/ProjectPcbProduceHistoryProfile.cs
+++ b/Binner/Library/Binner.Common/MappingProfiles/ModelCommon/ProjectPcbProduceHistoryProfile.cs
@@ -15,7 +15,7 @@ namespace Binner.Common.MappingProfiles.ModelCommon
                 .ForMember(x => x.PartsConsumed, options => options.MapFrom(x => x.PartsConsumed))
                 .ForMember(x => x.PcbQuantity, options => options.MapFrom(x => x.PcbQuantity))
                 .ForMember(x => x.PcbCost, options => options.MapFrom(x => x.PcbCost))
-                .ForMember(x => x.ProjectPcbProduceHistoryId, options => options.MapFrom(x => x.ProjectPcbProduceHistoryId))
+                .ForMember(x => x.ProjectPcbProduceHistoryId, options => options.Ignore())
                 .ForMember(x => x.UserId, options => options.Ignore())
                 .ForMember(x => x.OrganizationId, options => options.Ignore())
                 .ForMember(x => x.Pcb, options => options.Ignore())

--- a/Binner/Library/Binner.Common/Services/AdminService.cs
+++ b/Binner/Library/Binner.Common/Services/AdminService.cs
@@ -101,12 +101,31 @@ namespace Binner.Common.Services
                     model.StorageProviderSettings = _storageProviderConfiguration.ProviderConfiguration["Filename"];
                     break;
                 default:
-                    model.StorageProviderSettings = _storageProviderConfiguration.ProviderConfiguration["ConnectionString"];
-                    var builder = new DbConnectionStringBuilder();
-                    builder.ConnectionString = model.StorageProviderSettings;
-                    if (builder.ContainsKey("Password"))
+                    if (_storageProviderConfiguration.ProviderConfiguration.ContainsKey("ConnectionString") && !string.IsNullOrEmpty(_storageProviderConfiguration.ProviderConfiguration["ConnectionString"]))
                     {
-                        builder["Password"] = "********";
+                        model.StorageProviderSettings = _storageProviderConfiguration.ProviderConfiguration["ConnectionString"];
+                        var builder = new DbConnectionStringBuilder();
+                        builder.ConnectionString = model.StorageProviderSettings;
+                        if (builder.ContainsKey("Password"))
+                        {
+                            builder["Password"] = "********";
+                            model.StorageProviderSettings = builder.ToString();
+                        }
+                    }
+                    else
+                    {
+                        model.StorageProviderSettings = "";
+                        var builder = new DbConnectionStringBuilder();
+                        if (_storageProviderConfiguration.ProviderConfiguration.ContainsKey("Host") && !string.IsNullOrEmpty(_storageProviderConfiguration.ProviderConfiguration["Host"]))
+                            builder["Host"] = _storageProviderConfiguration.ProviderConfiguration["Host"];
+                        if (_storageProviderConfiguration.ProviderConfiguration.ContainsKey("Port") && !string.IsNullOrEmpty(_storageProviderConfiguration.ProviderConfiguration["Port"]))
+                            builder["Port"] = _storageProviderConfiguration.ProviderConfiguration["Port"];
+                        if (_storageProviderConfiguration.ProviderConfiguration.ContainsKey("Database") && !string.IsNullOrEmpty(_storageProviderConfiguration.ProviderConfiguration["Database"]))
+                            builder["Database"] = _storageProviderConfiguration.ProviderConfiguration["Database"];
+                        if (_storageProviderConfiguration.ProviderConfiguration.ContainsKey("Username") && !string.IsNullOrEmpty(_storageProviderConfiguration.ProviderConfiguration["Username"]))
+                            builder["Username"] = _storageProviderConfiguration.ProviderConfiguration["Username"];
+                        if (_storageProviderConfiguration.ProviderConfiguration.ContainsKey("Password") && !string.IsNullOrEmpty(_storageProviderConfiguration.ProviderConfiguration["Password"]))
+                            builder["Password"] = "********";
                         model.StorageProviderSettings = builder.ToString();
                     }
                     break;

--- a/Binner/Library/Binner.Common/Services/IntegrationService.cs
+++ b/Binner/Library/Binner.Common/Services/IntegrationService.cs
@@ -148,6 +148,10 @@ namespace Binner.Common.Services
                                 return new TestApiResponse(nameof(Integrations.MouserApi), string.Join(". ", result.Errors));
                             return new TestApiResponse(nameof(Integrations.MouserApi), true);
                         }
+                        catch (MouserErrorsException ex)
+                        {
+                            return new TestApiResponse(nameof(Integrations.MouserApi), string.Join(". ", ex.Errors.Select(x => x.Message)));
+                        }
                         catch (Exception ex)
                         {
                             return new TestApiResponse(nameof(Integrations.MouserApi), ex.GetBaseException().Message);

--- a/Binner/Library/Binner.Common/Services/IntegrationService.cs
+++ b/Binner/Library/Binner.Common/Services/IntegrationService.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Binner.Model.Configuration.Integrations;
 
 namespace Binner.Common.Services
 {
@@ -143,10 +144,23 @@ namespace Binner.Common.Services
                             return new TestApiResponse(nameof(Integrations.MouserApi), "Api is not enabled.");
                         try
                         {
-                            var result = await api.SearchAsync("LM555", 1);
-                            if (result.Errors.Any())
-                                return new TestApiResponse(nameof(Integrations.MouserApi), string.Join(". ", result.Errors));
-                            return new TestApiResponse(nameof(Integrations.MouserApi), true);
+                            if (((MouserConfiguration)api.Configuration).IsConfigured)
+                            {
+                                var result = await api.SearchAsync("LM555", 1);
+                                if (result.Errors.Any())
+                                    return new TestApiResponse(nameof(Integrations.MouserApi), string.Join(". ", result.Errors));
+                                return new TestApiResponse(nameof(Integrations.MouserApi), true);
+                            }
+
+                            if (((MouserConfiguration)api.Configuration).IsOrdersConfigured)
+                            {
+                                var result = await api.GetOrderAsync("1111111");
+                                if (result.Errors.Any() && !result.Errors.First().EndsWith("Not Found"))
+                                    return new TestApiResponse(nameof(Integrations.MouserApi), string.Join(". ", result.Errors));
+                                return new TestApiResponse(nameof(Integrations.MouserApi), true);
+                            }
+
+                            return new TestApiResponse(nameof(Integrations.MouserApi), false);
                         }
                         catch (MouserErrorsException ex)
                         {

--- a/Binner/Library/Binner.Common/Services/ProjectService.cs
+++ b/Binner/Library/Binner.Common/Services/ProjectService.cs
@@ -356,11 +356,18 @@ namespace Binner.Common.Services
                 .FirstOrDefaultAsync();
 
             entity = _mapper.Map(request, entity);
-            foreach (var pcb in request.Pcbs)
+            foreach (var pcbEntity in entity.ProjectPcbProduceHistory)
             {
-                var pcbEntity = entity.ProjectPcbProduceHistory.FirstOrDefault(x => x.PcbId == pcb.PcbId);
-                if (pcbEntity != null)
-                    pcbEntity = _mapper.Map(pcb, pcbEntity);
+                var pcb = request.Pcbs.FirstOrDefault(x => x.ProjectPcbProduceHistoryId == pcbEntity.ProjectPcbProduceHistoryId);
+                if (pcb != null)
+                {
+                    var updatedPcbEntity = _mapper.Map(pcb, pcbEntity);
+                    pcbEntity.PartsConsumed = updatedPcbEntity.PartsConsumed;
+                    pcbEntity.PcbQuantity = updatedPcbEntity.PcbQuantity;
+                    pcbEntity.PcbCost = updatedPcbEntity.PcbCost;
+                    pcbEntity.SerialNumber = updatedPcbEntity.SerialNumber;
+                    pcbEntity.DateModifiedUtc = DateTime.UtcNow;
+                }
             }
             await context.SaveChangesAsync();
 

--- a/Binner/Library/Binner.Model/Part.cs
+++ b/Binner/Library/Binner.Model/Part.cs
@@ -140,6 +140,26 @@ namespace Binner.Model
         public int? UserId { get; set; }
 
         /// <summary>
+        /// KiCad symbol name
+        /// </summary>
+        public string? SymbolName { get; set; }
+
+        /// <summary>
+        /// KiCad footprint name
+        /// </summary>
+        public string? FootprintName { get; set; }
+
+        /// <summary>
+        /// Extension value 1 (can be used to store custom information)
+        /// </summary>
+        public string? ExtensionValue1 { get; set; }
+
+        /// <summary>
+        /// Extension value 2 (can be used to store custom information)
+        /// </summary>
+        public string? ExtensionValue2 { get; set; }
+
+        /// <summary>
         /// The date the record was created
         /// </summary>
         public DateTime DateCreatedUtc { get; set; } = DateTime.UtcNow;

--- a/Binner/Library/Binner.Model/Requests/PartBase.cs
+++ b/Binner/Library/Binner.Model/Requests/PartBase.cs
@@ -126,5 +126,25 @@
         /// The raw barcode that was scanned
         /// </summary>
         public string? Barcode { get; set; }
+
+        /// <summary>
+        /// KiCad symbol name
+        /// </summary>
+        public string? SymbolName { get; set; }
+
+        /// <summary>
+        /// KiCad footprint name
+        /// </summary>
+        public string? FootprintName { get; set; }
+
+        /// <summary>
+        /// Extension value 1 (can be used to store custom information)
+        /// </summary>
+        public string? ExtensionValue1 { get; set; }
+
+        /// <summary>
+        /// Extension value 2 (can be used to store custom information)
+        /// </summary>
+        public string? ExtensionValue2 { get; set; }
     }
 }

--- a/Binner/Library/Binner.Model/Responses/PartResponse.cs
+++ b/Binner/Library/Binner.Model/Responses/PartResponse.cs
@@ -136,5 +136,25 @@
         /// The Arrow part number
         /// </summary>
         public string? ArrowPartNumber { get; set; }
+
+        /// <summary>
+        /// KiCad symbol name
+        /// </summary>
+        public string? SymbolName { get; set; }
+
+        /// <summary>
+        /// KiCad footprint name
+        /// </summary>
+        public string? FootprintName { get; set; }
+
+        /// <summary>
+        /// Extension value 1 (can be used to store custom information)
+        /// </summary>
+        public string? ExtensionValue1 { get; set; }
+
+        /// <summary>
+        /// Extension value 2 (can be used to store custom information)
+        /// </summary>
+        public string? ExtensionValue2 { get; set; }
     }
 }


### PR DESCRIPTION
* Fixes #198 - Label Editor: Label editing error
  * Label generator failed to convert non-string value types
* fixes the issue where a new database doesn't get initialized properly if it is pre-created ahead of time
* fixes a few bugs with produce history and editing, found by @pdo59
* fixes system info page which didn't know about the new storage provider config format.
* fixed mouser api key validations as empty keys are valid (unless ALL are empty)
* fixes a bug when saving edits on a BOM project
* fixes part type icon not displaying correctly in Firefox
* Added support for associating KiCad symbols, or other external values to a part.
* adds a css fix for firefox not supporting :has selectors
* fixes some part number links that should have url encoded the values
* adds popup to explain Maker subscription is required to access feature
* fixed part types icon selection modal so it's a little easier to use. added an svg preview.
