### PR TITLE
Add possibility to overload appsettings.json with environment variables

### DIFF
--- a/Binner/Binner.Web/Program.cs
+++ b/Binner/Binner.Web/Program.cs
@@ -16,8 +16,9 @@ using Topshelf.Runtime;
 WebApplicationBuilder builder;
 WebHostServiceConfiguration? config;
 try
-{
+{    // Question : Can we use Config class to reduce the risk of error with BinnerWebHostService.InitializeWebHostAsync ?
     builder = WebApplication.CreateBuilder();
+    builder.Configuration.AddEnvironmentVariables();
     config = builder.Configuration.GetSection(nameof(WebHostServiceConfiguration)).Get<WebHostServiceConfiguration>();
     if (config == null)
     {

--- a/Binner/Library/Binner.Common/Config.cs
+++ b/Binner/Library/Binner.Common/Config.cs
@@ -14,7 +14,8 @@ namespace Binner.Common
                 throw new FileNotFoundException($"The configuration file named '{filePath}' was not found.");
             var builder = new ConfigurationBuilder()
                 .SetBasePath(path)
-                .AddJsonFile(appSettingsJson, optional: false, reloadOnChange: true);
+                .AddJsonFile(appSettingsJson, optional: false, reloadOnChange: true)
+                .AddEnvironmentVariables();
             return builder.Build();
         }
     }


### PR DESCRIPTION
With this little modification, you can overload all appsettings.json content with environment variable.

This is very useful if you want to install Binner in docker container without adding config file.

For example, if you want to change the WebHostServiceConfiguration.Port configuration to 9090, simply set this environment variable before launch the app :

```
export WebHostServiceConfiguration__Port=9090
```

This is working for all possible variables. Follow this [documentation](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-8.0#non-prefixed-environment-variables) for more details.