### PR TITLE
removed cost input restriction

### DIFF
--- a/Binner/Binner.Web/ClientApp/src/pages/Inventory.js
+++ b/Binner/Binner.Web/ClientApp/src/pages/Inventory.js
@@ -629,7 +629,7 @@ export function Inventory(props) {
       default:
         break;
       case "cost":
-        part.cost = Number(part.cost).toFixed(2);
+        part.cost = Number(part.cost);
         if (isNaN(part.cost)) part.cost = Number(0).toFixed(2);
         break;
     }


### PR DESCRIPTION
As discribed in issue #285 i had issues with inputting cost for very low cost items, due to reformatting clipping off anything after 2 decemalplaces. 

in my tests this change is only for the better. maybe something to be aware of is if very very small numbers are inputted it will now format them into scientific notation, but this did not seem to cause any issues