### PR TITLE
Allow the appsettings.json to be defined via env variable CONFIG_DIR

### DIFF
--- a/Binner/Binner.Web/Configuration/StartupConfiguration.cs
+++ b/Binner/Binner.Web/Configuration/StartupConfiguration.cs
@@ -19,7 +19,7 @@ namespace Binner.Web.Configuration
         {
             //var configPath = AppDomain.CurrentDomain.BaseDirectory;
             //var configPath = Environment.CurrentDirectory;
-            var configPath = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule!.FileName) ?? string.Empty;
+            var configPath = Environment.GetEnvironmentVariable("CONFIG_DIR") ?? Path.GetDirectoryName(Process.GetCurrentProcess().MainModule!.FileName) ?? string.Empty;
             var configFile = Path.Combine(configPath, ConfigFile);
             Console.WriteLine($".Net Core bundle path: {AppContext.BaseDirectory}");
             Console.WriteLine($"Config file location: {configFile}");


### PR DESCRIPTION
This makes the usage via docker/kubernetes much easier since we can split the code and the data making the last one persisted in a volume.

Example:
- Set the env `CONFIG_DIR` to `/app/data`
- All code is inside `/app`
- database and config is inside `/app/data`
- a new volume is mounted for `/app/data`

Docker Image for ARM64: https://github.com/csobrinho/binner-docker
Kubernetes app: https://github.com/csobrinho/homelab/tree/main/apps/binner/overlays/prod

PS: My C# is rusty so please double-check both the syntax and codestyle fits, thanks!