### PR TITLE
Added a width input field using user cookie

### DIFF
--- a/Binner/Binner.Web/ClientApp/src/common/authentication.js
+++ b/Binner/Binner.Web/ClientApp/src/common/authentication.js
@@ -4,6 +4,7 @@ export const EmptyUserAccount = {
   userId: 0,
   isAuthenticated: false,
   name: "",
+  maxWidth: "50%",
   accessToken: "",
 	imagesToken: "",
 	isAdmin: false,

--- a/Binner/Binner.Web/ClientApp/src/layouts/Layout.js
+++ b/Binner/Binner.Web/ClientApp/src/layouts/Layout.js
@@ -8,6 +8,7 @@ import { Outlet } from "react-router-dom";
 // components
 import ErrorModal from "../components/modals/ErrorModal";
 import LicenseErrorModal from "../components/modals/LicenseErrorModal";
+import { getUserAccount } from "../common/authentication";
 
 export function Layout(props) {
   const { t } = useTranslation('en');
@@ -125,10 +126,14 @@ export function Layout(props) {
     }
   };
 
+  // Get the max-width from local storage
+  const userAccount = getUserAccount();
+  const maxWidth = (userAccount && userAccount.maxWidth) || '50%';
+
   return (
     <div className="centered" style={{marginBottom: '50px', position: 'relative', zIndex: '50', textAlign: 'left'}}>
       <div id="banner" />
-      <Container>
+      <Container style={{ maxWidth: maxWidth }}>
         <Header />
         <Outlet />
         <Footer />


### PR DESCRIPTION
Added a input box to set the max page width of the container. ([discussion 393](https://github.com/replaysMike/Binner/discussions/393))

![image](https://github.com/user-attachments/assets/c1c0a7b0-3f5c-4059-a095-6516e8945ad9)

This uses the user cookie to store the `maxWidth` of the container. Default width is 50%. If the user does not have the `maxWidth` set in the cookie.