### PR TITLE
Bugfix mouser row.original.status null #391

### DIFF
--- a/Binner/Binner.Web/ClientApp/src/pages/Datasheets.js
+++ b/Binner/Binner.Web/ClientApp/src/pages/Datasheets.js
@@ -217,7 +217,13 @@ export function Datasheets (props) {
         case 'website':
           return {...def, Cell: ({row}) => (<span>{row.original.swarmPartNumberManufacturerId ? "Binner Swarm" : getHostnameFromRegex(_.first(row.original.datasheetUrls))}</span>)};
         case 'status':
-          return {...def, Cell: ({row}) => (<span>{row.original.status === "Inactive" ? <span style={{color: '#bbb'}}>{t(row.original.status.toLowerCase(), row.original.status)}</span> : <b>{t(row.original.status.toLowerCase(), row.original.status)}</b>}</span>)};
+          return {...def, Cell: ({row}) => (<span>{
+                row.original.status !== null ? (row.original.status === "Inactive" ? 
+                    <span style={{color: '#bbb'}}>{t(row.original.status.toLowerCase(), row.original.status)}</span> : 
+                    <b>{t(row.original.status.toLowerCase(), row.original.status)}</b>
+                ) : ""
+            }</span>
+          )};
         case 'actions': 
           return {...def, Header: <i key={key}>{t('page.datasheet.datasheets', "Datasheets")}</i>, columnDefType: 'display', Cell: ({row}) => (
             <>


### PR DESCRIPTION
Fixes the issue in #391 if you search for "lpc1756" in the datasheet screen. Two of the results did not have a status. I added a null check around it.

![image](https://github.com/user-attachments/assets/f662a3af-7935-423e-b833-45d02fb426fa)
