### PR TITLE
Added support for Kicad description/Ref/Symbol id in part types

### DIFF
--- a/Binner/Binner.Web/ClientApp/src/pages/PartTypes.js
+++ b/Binner/Binner.Web/ClientApp/src/pages/PartTypes.js
@@ -154,6 +154,18 @@ export function PartTypes(props) {
     setModalContext({ ...modalContext, name: control.value });
   };
 
+  const handleDescriptionChange = (e, control) => {
+    setModalContext({ ...modalContext, description: control.value });
+  };
+
+  const handleReferenceDesignatorChange = (e, control) => {
+    setModalContext({ ...modalContext, referenceDesignator: control.value });
+  };
+
+  const handleSymbolIdChange = (e, control) => {
+    setModalContext({ ...modalContext, symbolId: control.value });
+  };
+
   const handleNewPartTypeIconNameChange = (e, control) => {
     setIconDropdown("");
     setModalContext({ ...modalContext, svg: control.value, icon: "" });
@@ -172,7 +184,10 @@ export function PartTypes(props) {
     setBtnAddDisabled(true);
     const request = {
       name: partType.name,
-      parentPartTypeId: Number.parseInt(partType.parentPartTypeId)
+      parentPartTypeId: Number.parseInt(partType.parentPartTypeId),
+      Description: partType.description,
+      ReferenceDesignator: partType.referenceDesignator,
+      SymbolId: partType.symbolId
     };
     const response = await fetchApi("/api/partType", {
       method: "POST",
@@ -590,7 +605,16 @@ export function PartTypes(props) {
               <Form.Input label="New Name" name="name" value={modalContext?.name || ''} onChange={handleNewPartTypeNameChange} />
             </Form.Field>
             <Form.Field>
-              <Form.Dropdown className="icons" selection fluid value={iconDropdown} options={iconNames} onChange={handleNewPartTypeIconChange}  />
+              <Form.Input label="Description" name="Description" value={modalContext?.description || ''} onChange={handleDescriptionChange} />
+            </Form.Field>
+            <Form.Field>
+              <Form.Input label="Reference designator" name="referenceDesignator" value={modalContext?.referenceDesignator || ''} onChange={handleReferenceDesignatorChange} />
+            </Form.Field>
+            <Form.Field>
+              <Form.Input label="Symbol id" name="symbolId" value={modalContext?.symbolId || ''} onChange={handleSymbolIdChange} />
+            </Form.Field>
+            <Form.Field>
+              <Form.Dropdown label="Parent" className="icons" selection fluid value={iconDropdown} options={iconNames} onChange={handleNewPartTypeIconChange}  />
               <Popup 
                 wide="very"
                 hoverable
@@ -660,6 +684,30 @@ export function PartTypes(props) {
                     value={partType.name}
                     onChange={handleChange}
                     name="name"
+                  />
+                </Form.Field>
+                <Form.Field>
+                  <Form.Input width={8}
+                    label={t("label.Description", "Description")}
+                    value={partType.description}
+                    onChange={handleChange}
+                    name="description"
+                  />
+                </Form.Field>
+                <Form.Field>
+                  <Form.Input width={8}
+                    label={t("label.ReferenceDesignator", "Reference designator")}
+                    value={partType.referenceDesignator}
+                    onChange={handleChange}
+                    name="referenceDesignator"
+                  />
+                </Form.Field>
+                <Form.Field>
+                  <Form.Input width={8}
+                    label={t("label.SymbolId", "Symbol id")}
+                    value={partType.symbolId}
+                    onChange={handleChange}
+                    name="symbolId"
                   />
                 </Form.Field>
                 <Form.Field width={8}>

--- a/Binner/Binner.Web/ClientApp/src/pages/PartTypes.js
+++ b/Binner/Binner.Web/ClientApp/src/pages/PartTypes.js
@@ -614,7 +614,7 @@ export function PartTypes(props) {
               <Form.Input label="Symbol id" name="symbolId" value={modalContext?.symbolId || ''} onChange={handleSymbolIdChange} />
             </Form.Field>
             <Form.Field>
-              <Form.Dropdown label="Parent" className="icons" selection fluid value={iconDropdown} options={iconNames} onChange={handleNewPartTypeIconChange}  />
+              <Form.Dropdown label="Icon" className="icons" selection fluid value={iconDropdown} options={iconNames} onChange={handleNewPartTypeIconChange}  />
               <Popup 
                 wide="very"
                 hoverable

--- a/Binner/Data/Binner.StorageProvider.EntityFrameworkCore/EntityFrameworkStorageProvider.cs
+++ b/Binner/Data/Binner.StorageProvider.EntityFrameworkCore/EntityFrameworkStorageProvider.cs
@@ -1225,7 +1225,10 @@ INNER JOIN (
                     ParentPartTypeId = partType.ParentPartTypeId,
                     PartTypeId = partType.PartTypeId,
                     UserId = userContext.UserId,
-                    OrganizationId = userContext.OrganizationId
+                    OrganizationId = userContext.OrganizationId,
+                    Description = partType.Description,
+                    SymbolId = partType.SymbolId,
+                    ReferenceDesignator = partType.ReferenceDesignator
                 };
                 context.PartTypes.Add(entity);
                 await context.SaveChangesAsync();

--- a/Binner/Library/Binner.Model/Requests/CreatePartTypeRequest.cs
+++ b/Binner/Library/Binner.Model/Requests/CreatePartTypeRequest.cs
@@ -17,5 +17,20 @@
         /// Description of project
         /// </summary>
         public long? ParentPartTypeId { get; set; }
+
+        /// <summary>
+        /// Part type description
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// Reference designator
+        /// </summary>
+        public string? ReferenceDesignator { get; set; }
+
+        /// <summary>
+        /// The symbol id of the part type (KiCad)
+        /// </summary>
+        public string? SymbolId { get; set; }
     }
 }

--- a/Binner/Library/Binner.Model/Requests/UpdatePartTypeRequest.cs
+++ b/Binner/Library/Binner.Model/Requests/UpdatePartTypeRequest.cs
@@ -19,6 +19,21 @@
         public string? Icon { get;set; }
 
         /// <summary>
+        /// Part type description
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// Reference designator
+        /// </summary>
+        public string? ReferenceDesignator { get; set; }
+
+        /// <summary>
+        /// The symbol id of the part type (KiCad)
+        /// </summary>
+        public string? SymbolId { get; set; }
+
+        /// <summary>
         /// Description of project
         /// </summary>
         public long? ParentPartTypeId { get; set; }


### PR DESCRIPTION
This PR adds the description/reference designator and symbol id to the part types menus (#400), also fixes a missing label in the edit of the part types menu. This also partially fixes issue #399 as you can enter something now to prevent the `null` in the json

![image](https://github.com/user-attachments/assets/57a3793a-b186-4ffc-9d2d-359236398b9a)

Same data is forwarded to KiCad

![image](https://github.com/user-attachments/assets/2ac93233-49b2-4d2f-85f0-f32212e70e8a)
