### PR TITLE
Added a toggle to disable automatic searching while typing in the "Part" input field

### DIFF
--- a/Binner/Binner.Web/ClientApp/src/common/authentication.js
+++ b/Binner/Binner.Web/ClientApp/src/common/authentication.js
@@ -5,8 +5,9 @@ export const EmptyUserAccount = {
   isAuthenticated: false,
   name: "",
   accessToken: "",
-	imagesToken: "",
-	isAdmin: false,
+  imagesToken: "",
+  isAdmin: false,
+  automaticSearch: true,
 };
 
 /**
@@ -140,7 +141,16 @@ export const isAuthenticated = () => {
  * Check if the user is an admin
  * @returns {boolean} true if the user is an admin user
  */
- export const isAdmin = () => {
+export const isAdmin = () => {
   const user = getUserAccount();
   return user && user.isAdmin;
+};
+
+/**
+ * Checks if automatic search is enabled
+ * @returns 
+ */
+export const automaticSearch = () => {
+  const user = getUserAccount();
+  return user && user.automaticSearch;
 };

--- a/Binner/Binner.Web/ClientApp/src/pages/Login.js
+++ b/Binner/Binner.Web/ClientApp/src/pages/Login.js
@@ -41,7 +41,8 @@ export function Login (props) {
           subscriptionLevel: data.subscriptionLevel,
           accessToken: data.jwtToken,
           imagesToken: data.imagesToken,
-          isAdmin: data.isAdmin
+          isAdmin: data.isAdmin,
+          automaticSearch: data.automaticSearch,
         });
 				localStorage.setItem("showWelcome", true);
         navigate("/", { replace: true, state: { } });

--- a/Binner/Binner.Web/ClientApp/src/pages/Settings.js
+++ b/Binner/Binner.Web/ClientApp/src/pages/Settings.js
@@ -353,6 +353,7 @@ export const Settings = (props) => {
     maxCacheItems: 1024,
     cacheAbsoluteExpirationMinutes: 0,
     cacheSlidingExpirationMinutes: 30,
+    automaticSearch: true,
   });
   const [integrationSettings, setIntegrationSettings] = useState({
     binner: {
@@ -567,10 +568,10 @@ export const Settings = (props) => {
         const { data } = response;
         setLoading(false);
         // break out data into multiple state variables to optimize render performance
-        const { licenseKey, maxCacheItems, cacheAbsoluteExpirationMinutes, cacheSlidingExpirationMinutes } = data;
+        const { licenseKey, maxCacheItems, cacheAbsoluteExpirationMinutes, cacheSlidingExpirationMinutes, automaticSearch } = data;
         const language = data.language.toLowerCase(); // to match lowercase option value
         const currency = data.currency.toUpperCase(); // to match uppercase option value
-        setGlobalSettings({ licenseKey, language, currency, maxCacheItems, cacheAbsoluteExpirationMinutes, cacheSlidingExpirationMinutes });
+        setGlobalSettings({ licenseKey, language, currency, maxCacheItems, cacheAbsoluteExpirationMinutes, cacheSlidingExpirationMinutes, automaticSearch });
         const { binner, digikey, mouser, arrow, octopart, tme } = data;
         setIntegrationSettings({ binner, digikey, mouser, arrow, octopart, tme });
         setPrinterSettings({ printer: data.printer });
@@ -718,7 +719,9 @@ export const Settings = (props) => {
   };
 
   const setControlValue = (setting, name, control) => {
-    if (control.name === `${name}Enabled` || control.name === `${name}IsDebug` || control.name === `${name}ResolveExternalLinks`) {
+    if (control.name === `${name}Enabled` || control.name === `${name}IsDebug` || 
+        control.name === `${name}ResolveExternalLinks` || control.name === `${name}automaticSearch`) 
+    {
       // for bool dropdowns, they don't advertise type!
       setting[getControlInstanceName(control, name)] = control.value > 0 ? true : false;
       return;
@@ -1105,6 +1108,29 @@ export const Settings = (props) => {
                 placeholder=""
                 value={globalSettings.cacheSlidingExpirationMinutes || 30}
                 name="cacheSlidingExpirationMinutes"
+                onChange={(e, control) => handleChange(e, control, 'global')}
+              />
+            }
+          />
+        </Form.Field>
+
+        <Form.Field width={10}>
+          <label>{t('label.automaticSearch', "Automatic Part Search")}</label>
+          <Popup
+            wide
+            position="top left"
+            offset={[120, 0]}
+            hoverable
+            content={
+              <p>{t('page.settings.popup.automaticSearch', "Choose if you would like to enable automatic part searching when typing in the \"Part\" input field")}</p>
+            }
+            trigger={
+              <Dropdown
+                name="automaticSearch"
+                placeholder="Enabled"
+                selection
+                value={globalSettings.automaticSearch ? 1 : 0}
+                options={enabledSources}
                 onChange={(e, control) => handleChange(e, control, 'global')}
               />
             }

--- a/Binner/Binner.Web/appsettings.json
+++ b/Binner/Binner.Web/appsettings.json
@@ -14,6 +14,8 @@
     "MaxCacheItems": 1024,
     "CacheSlidingExpirationMinutes": 30,
     "CacheAbsoluteExpirationMinutes": 0,
+    // set if we need to automaticly search while entering a part number
+    "AutomaticSearch": true,
     // set the maximum length of time the part types can be cached before forcing a refresh
     "MaxPartTypesCacheLifetime": "00:30:00",
     // allow the ability to login when passwords are empty in the database. See https://github.com/replaysMike/Binner/wiki/Lost-password-recovery

--- a/Binner/Library/Binner.Common/MappingProfiles/SettingsRequestProfile.cs
+++ b/Binner/Library/Binner.Common/MappingProfiles/SettingsRequestProfile.cs
@@ -26,6 +26,7 @@ namespace Binner.Common.MappingProfiles
                 .ForMember(x => x.MaxCacheItems, options => options.MapFrom(x => x.MaxCacheItems))
                 .ForMember(x => x.CacheSlidingExpirationMinutes, options => options.MapFrom(x => x.CacheSlidingExpirationMinutes))
                 .ForMember(x => x.CacheAbsoluteExpirationMinutes, options => options.MapFrom(x => x.CacheAbsoluteExpirationMinutes))
+                .ForMember(x => x.AutomaticSearch, options => options.MapFrom(x => x.AutomaticSearch))
                 .ForMember(x => x.CustomFields, options => options.Ignore())
                 .ReverseMap();
 

--- a/Binner/Library/Binner.Common/MappingProfiles/SettingsResponseProfile.cs
+++ b/Binner/Library/Binner.Common/MappingProfiles/SettingsResponseProfile.cs
@@ -27,6 +27,7 @@ namespace Binner.Common.MappingProfiles
                 .ForMember(x => x.MaxCacheItems, options => options.MapFrom(x => x.MaxCacheItems))
                 .ForMember(x => x.CacheSlidingExpirationMinutes, options => options.MapFrom(x => x.CacheSlidingExpirationMinutes))
                 .ForMember(x => x.CacheAbsoluteExpirationMinutes, options => options.MapFrom(x => x.CacheAbsoluteExpirationMinutes))
+                .ForMember(x => x.AutomaticSearch, options => options.MapFrom(x => x.AutomaticSearch))
                 .ForMember(x => x.CustomFields, options => options.Ignore())
                 .ReverseMap();
 
@@ -85,6 +86,7 @@ namespace Binner.Common.MappingProfiles
                 .ForMember(x => x.MaxCacheItems, options => options.Ignore())
                 .ForMember(x => x.CacheSlidingExpirationMinutes, options => options.Ignore())
                 .ForMember(x => x.CacheAbsoluteExpirationMinutes, options => options.Ignore())
+                .ForMember(x => x.AutomaticSearch, options => options.Ignore())
                 .ForMember(x => x.CustomFields, options => options.Ignore())
                 .ReverseMap();
 

--- a/Binner/Library/Binner.Common/Services/AuthenticationService.cs
+++ b/Binner/Library/Binner.Common/Services/AuthenticationService.cs
@@ -70,7 +70,7 @@ namespace Binner.Common.Services
                     if (isLoginAllowed)
                     {
                         // authenticated
-                        var authenticationResponse = await CreateAuthenticationLoginAsync(context, user, userContext);
+                        var authenticationResponse = await CreateAuthenticationLoginAsync(context, user, userContext, _configuration.AutomaticSearch);
                         if (!authenticationResponse.IsAuthenticated)
                             _logger.LogWarning($"[{nameof(AuthenticateAsync)}] {authenticationResponse.Message}. Username: '{model.Username}' IP: {_requestContext.GetIpAddress()}");
 
@@ -112,7 +112,7 @@ namespace Binner.Common.Services
             }
         }
 
-        private async Task<AuthenticationResponse> CreateAuthenticationLoginAsync(BinnerContext context, Data.Model.User user, UserContext userContext)
+        private async Task<AuthenticationResponse> CreateAuthenticationLoginAsync(BinnerContext context, Data.Model.User user, UserContext userContext, bool autoSearch)
         {
             // are they allowed to login?
             if (!user.IsEmailConfirmed)
@@ -150,7 +150,7 @@ namespace Binner.Common.Services
 
             // remove old refresh tokens from user
             await RemoveOldUserTokensAsync(context, user);
-            return new AuthenticationResponse(userContext, authenticatedTokens);
+            return new AuthenticationResponse(userContext, authenticatedTokens, autoSearch);
         }
 
         public async Task<AuthenticationResponse> RefreshTokenAsync(string token)
@@ -226,7 +226,7 @@ namespace Binner.Common.Services
                 RefreshToken = newRefreshToken.Token,
                 DateCreated = newRefreshToken.Created,
                 DateExpires = newRefreshToken.Expires
-            });
+            }, _configuration.AutomaticSearch);
         }
 
         public async Task RevokeTokenAsync(string token)
@@ -481,7 +481,7 @@ namespace Binner.Common.Services
 
                 // login the user
                 var userContext = Map(user);
-                var authenticationResponse = await CreateAuthenticationLoginAsync(context, user, userContext);
+                var authenticationResponse = await CreateAuthenticationLoginAsync(context, user, userContext, _configuration.AutomaticSearch);
 
                 return authenticationResponse;
             }

--- a/Binner/Library/Binner.Model/Configuration/WebHostServiceConfiguration.cs
+++ b/Binner/Library/Binner.Model/Configuration/WebHostServiceConfiguration.cs
@@ -216,5 +216,10 @@
         /// Barcode configuration
         /// </summary>
         public BarcodeConfiguration Barcode { get; set; } = new();
+
+        /// <summary>
+        /// Flag if we should automatically search when the user is entering a partnumber
+        /// </summary>
+        public bool AutomaticSearch { get; set; } = true;
     }
 }

--- a/Binner/Library/Binner.Model/Requests/SettingsRequest.cs
+++ b/Binner/Library/Binner.Model/Requests/SettingsRequest.cs
@@ -80,5 +80,11 @@ namespace Binner.Model.Requests
         /// Absolute cache expiration in minutes (0 = never)
         /// </summary>
         public int CacheAbsoluteExpirationMinutes { get; set; } = 0;
+
+        /// <summary>
+        /// Flag if we should automatically search when the 
+        /// user is entering a partnumber
+        /// </summary>
+        public bool AutomaticSearch { get; set; } = true;
     }
 }

--- a/Binner/Library/Binner.Model/Responses/AuthenticationResponse.cs
+++ b/Binner/Library/Binner.Model/Responses/AuthenticationResponse.cs
@@ -30,13 +30,19 @@ namespace Binner.Model.Responses
         /// </summary>
         public bool IsAdmin { get; set; }
 
+        /// <summary>
+        /// Flag if we should automatically search when the 
+        /// user is entering a partnumber
+        /// </summary>
+        public bool automaticSearch { get; set; }
+
         public AuthenticationResponse(bool isAuthenticated, string message)
         {
             IsAuthenticated = isAuthenticated;
             Message = message;
         }
 
-        public AuthenticationResponse(UserContext user, AuthenticatedTokens authenticatedTokens)
+        public AuthenticationResponse(UserContext user, AuthenticatedTokens authenticatedTokens, bool autoSearch)
         {
             Id = user.UserId;
             OrganizationId = user.OrganizationId;
@@ -47,6 +53,7 @@ namespace Binner.Model.Responses
             RefreshToken = authenticatedTokens.RefreshToken;
             CanLogin = authenticatedTokens.CanLogin;
             IsAdmin = user.IsAdmin;
+            automaticSearch = autoSearch;
         }
     }
 }

--- a/Binner/Library/Binner.Model/Responses/SettingsResponse.cs
+++ b/Binner/Library/Binner.Model/Responses/SettingsResponse.cs
@@ -78,5 +78,11 @@ namespace Binner.Model.Responses
         /// Absolute cache expiration in minutes (0 = never)
         /// </summary>
         public int CacheAbsoluteExpirationMinutes { get; set; } = 0;
+
+        /// <summary>
+        /// Flag if we should automatically search when the 
+        /// user is entering a partnumber
+        /// </summary>
+        public bool AutomaticSearch { get; set; } = true;
     }
 }


### PR DESCRIPTION
This adds support to disable/enable the automatic searching of parts using the API integrations. This makes Binner more fluent when the api calls take multiple seconds. (Most likely the cause for the skipped user input #424). What this does is it disables the fetching part of the 'handleInputPartNumberChange' and only fetches the data when the user presses the search icon.

![image](https://github.com/user-attachments/assets/10f4a0a2-5fad-41b1-8d8d-f6765173f9eb)

Also partially fixes the issue in #425 as it only searches once

Note: Uses user cookie so every user needs to refresh their cookie before this takes effect on that specific user