### PR TITLE
#460 Fixed issue where non default part types where causing a null error on fi

### DIFF
--- a/Binner/Library/Binner.Services/Integrations/BaseIntegrationBehavior.cs
+++ b/Binner/Library/Binner.Services/Integrations/BaseIntegrationBehavior.cs
@@ -96,6 +96,11 @@ namespace Binner.Services.Integrations
             var typeOfEnum = partTypeEnum.GetType();
             var fi = typeOfEnum.GetField(partTypeEnum.ToString());
 
+            if (fi == null)
+            {
+                return null;
+            }
+
             //get the attribute from the field
             return fi.GetCustomAttributes(typeof(PartTypeInfoAttribute), false).
                 FirstOrDefault()


### PR DESCRIPTION
For non default types part types fi returns null as they do not exist in the default enum. I added a null check so it does not throw the error anymore. Issue #460 has more info